### PR TITLE
Other runtimes (closes #2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo check --all-targets --features testing
+cargo check --all-targets --all-features

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 make clippy
-cargo test --features testing
+make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,29 +84,16 @@ jobs:
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
-      - name: Build docs
-        run: cargo doc --no-default-features --features testing --verbose --target ${{ matrix.platform.rust-target }}
-
       - name: Build (no features)
         run: cargo build --no-default-features --verbose --target ${{ matrix.platform.rust-target }}
 
       - name: Build (all additive features)
-        run: cargo build --no-default-features --features testing --verbose --target ${{ matrix.platform.rust-target }}
+        run: cargo build --all-features --verbose --target ${{ matrix.platform.rust-target }}
 
       # Run tests (except on PyPy, because no embedding API).
       - if: matrix.python-version != 'pypy-3.6'
         name: Test
-        run: cargo test --no-default-features --features testing --target ${{ matrix.platform.rust-target }}
-
-      # Run tests again, but in abi3 mode
-      - if: matrix.python-version != 'pypy-3.6'
-        name: Test (abi3)
-        run: cargo test --no-default-features --features testing --target ${{ matrix.platform.rust-target }}
-
-      # Run tests again, for abi3-py36 (the minimal Python version)
-      - if: (matrix.python-version != 'pypy-3.6') && (matrix.python-version != '3.6')
-        name: Test (abi3-py36)
-        run: cargo test --no-default-features --features testing --target ${{ matrix.platform.rust-target }}
+        run: cargo test --all-features --target ${{ matrix.platform.rust-target }}
 
       - name: Install python test dependencies
         run: |
@@ -138,7 +125,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test 
-          args: --features testing
+          args: --all-features
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -21,7 +21,7 @@ jobs:
         # This adds the docs to gh-pages-build/doc
       - name: Build the doc
         run: |
-          cargo doc --no-deps --features testing
+          cargo doc --no-deps --all-features
           mkdir -p gh-pages-build
           cp -r target/doc gh-pages-build/doc
           echo "<meta http-equiv=refresh content=0;url=pyo3_asyncio/index.html>" > gh-pages-build/doc/index.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,35 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+async-std-runtime = ["async-std"]
 testing = ["clap"]
+tokio-runtime = ["tokio"]
 default = []
 
-[[test]]
-name = "test_asyncio"
-path = "pytests/test_asyncio.rs"
-harness = false
-required-features = ["testing"]
 
 [[test]]
-name = "test_run_forever"
-path = "pytests/test_run_forever.rs"
+name = "test_async_std_asyncio"
+path = "pytests/test_async_std_asyncio.rs"
 harness = false
-required-features = ["testing"]
+required-features = ["async-std-runtime", "testing"]
+
+[[test]]
+name = "test_async_std_run_forever"
+path = "pytests/test_async_std_run_forever.rs"
+harness = false
+required-features = ["async-std-runtime", "testing"]
+
+[[test]]
+name = "test_tokio_asyncio"
+path = "pytests/test_tokio_asyncio.rs"
+harness = false
+required-features = ["tokio-runtime", "testing"]
+
+[[test]]
+name = "test_tokio_run_forever"
+path = "pytests/test_tokio_run_forever.rs"
+harness = false
+required-features = ["tokio-runtime", "testing"]
 
 [dependencies]
 clap = { version = "2.33", optional = true }
@@ -28,4 +43,13 @@ futures = "0.3"
 lazy_static = "1.4"
 once_cell = "1.5"
 pyo3 = "0.13"
-tokio = { version = "1.0", features = ["full"] }
+
+[dependencies.async-std]
+version = "1.9"
+features = ["unstable"]
+optional = true
+
+[dependencies.tokio]
+version = "1.0" 
+features = ["full"]
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,16 @@
 name = "pyo3-asyncio"
 version = "0.13.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
+readme = "README.md"
+keywords = ["pyo3", "pyo3-asyncio", "python", "cpython", "ffi", "async", "asyncio"]
+homepage = "https://github.com/awestlake87/pyo3-asyncio"
+repository = "https://github.com/awestlake87/pyo3-asyncio"
+documentation = "https://docs.rs/crate/pyo3-asyncio/"
+categories = ["api-bindings", "development-tools::ffi"]
+license = "Apache-2.0"
+exclude = ["/.gitignore", "/codecov.yml", "/Makefile"]
 edition = "2018"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,7 +20,6 @@ async-std-runtime = ["async-std"]
 testing = ["clap"]
 tokio-runtime = ["tokio"]
 default = []
-
 
 [[test]]
 name = "test_async_std_asyncio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,26 @@ harness = false
 required-features = ["async-std-runtime", "testing"]
 
 [[test]]
-name = "test_tokio_asyncio"
-path = "pytests/test_tokio_asyncio.rs"
+name = "test_tokio_current_thread_asyncio"
+path = "pytests/test_tokio_current_thread_asyncio.rs"
 harness = false
 required-features = ["tokio-runtime", "testing"]
 
 [[test]]
-name = "test_tokio_run_forever"
-path = "pytests/test_tokio_run_forever.rs"
+name = "test_tokio_current_thread_run_forever"
+path = "pytests/test_tokio_current_thread_run_forever.rs"
+harness = false
+required-features = ["tokio-runtime", "testing"]
+
+[[test]]
+name = "test_tokio_multi_thread_asyncio"
+path = "pytests/test_tokio_multi_thread_asyncio.rs"
+harness = false
+required-features = ["tokio-runtime", "testing"]
+
+[[test]]
+name = "test_tokio_multi_thread_run_forever"
+path = "pytests/test_tokio_multi_thread_run_forever.rs"
 harness = false
 required-features = ["tokio-runtime", "testing"]
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint: fmt clippy
 	@true
 
 test: lint
-	cargo test --features async-std-runtime --features tokio-runtime --features testing
+	cargo test --all-features
 
 publish: test
 	cargo publish

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint: fmt clippy
 	@true
 
 test: lint
-	cargo test --features testing
+	cargo test --features async-std-runtime --features tokio-runtime --features testing
 
 publish: test
 	cargo publish

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@
 
 > PyO3 Asyncio is a _brand new_ part of the broader PyO3 ecosystem. Feel free to open any issues for feature requests or bugfixes for this crate.
 
+## Known Problems
+
+Currently, this library can give spurious failures during finalization. A solution should be released for PyO3 soon, but in the meantime you can add this patch to your `Cargo.toml` to use the master branch for PyO3
+
+```toml
+[patch.crates-io]
+pyo3 = { git = "https://github.com/PyO3/pyo3" }
+```
+
 ## Quickstart
 
 Here we initialize the runtime, import Python's `asyncio` library and run the given future to completion using Python's default `EventLoop` and Tokio. Inside the future, we convert `asyncio` sleep into a Rust future and await it.
@@ -29,7 +38,7 @@ fn main() {
             let asyncio: PyObject = py.import("asyncio")?.into();
             
             // Run the event loop until the given future completes
-            pyo3_asyncio::run_until_complete(py, async move {
+            pyo3_asyncio::async_std::run_until_complete(py, async move {
                 Python::with_gil(|py| {
                     // convert asyncio.sleep into a Rust Future
                     pyo3_asyncio::into_future(

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pyo3 = { git = "https://github.com/PyO3/pyo3" }
 
 ## Quickstart
 
-Here we initialize the runtime, import Python's `asyncio` library and run the given future to completion using Python's default `EventLoop` and Tokio. Inside the future, we convert `asyncio` sleep into a Rust future and await it.
+Here we initialize the runtime, import Python's `asyncio` library and run the given future to completion using Python's default `EventLoop` and `async-std`. Inside the future, we convert `asyncio` sleep into a Rust future and await it.
 
 More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
 

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -1,0 +1,37 @@
+use std::{future::Future, thread, time::Duration};
+
+use pyo3::prelude::*;
+
+pub(super) const TEST_MOD: &'static str = r#"
+import asyncio 
+
+async def py_sleep(duration):
+    await asyncio.sleep(duration)
+
+async def sleep_for_1s(sleep_for):
+    await sleep_for(1)
+"#;
+
+pub(super) fn test_into_future(
+    py: Python,
+) -> PyResult<impl Future<Output = PyResult<()>> + Send + 'static> {
+    let test_mod: PyObject =
+        PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?.into();
+
+    Ok(async move {
+        Python::with_gil(|py| {
+            pyo3_asyncio::into_future(
+                py,
+                test_mod
+                    .call_method1(py, "py_sleep", (1.into_py(py),))?
+                    .as_ref(py),
+            )
+        })?
+        .await?;
+        Ok(())
+    })
+}
+
+pub(super) fn test_blocking_sleep() {
+    thread::sleep(Duration::from_secs(1));
+}

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -1,0 +1,136 @@
+use std::{future::Future, thread, time::Duration};
+
+use async_std::task;
+use pyo3::{prelude::*, wrap_pyfunction};
+
+use pyo3_asyncio::{
+    async_std::testing::{new_sync_test, test_main},
+    testing::Test,
+};
+
+#[pyfunction]
+fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
+    let secs = secs.extract()?;
+
+    pyo3_asyncio::async_std::into_coroutine(py, async move {
+        task::sleep(Duration::from_secs(secs)).await;
+        Python::with_gil(|py| Ok(py.None()))
+    })
+}
+
+const TEST_MOD: &'static str = r#"
+import asyncio 
+
+async def py_sleep(duration):
+    await asyncio.sleep(duration)
+
+async def sleep_for_1s(sleep_for):
+    await sleep_for(1)
+"#;
+
+fn test_into_coroutine(
+    py: Python,
+) -> PyResult<impl Future<Output = PyResult<()>> + Send + 'static> {
+    let sleeper_mod: Py<PyModule> = PyModule::new(py, "rust_sleeper")?.into();
+
+    sleeper_mod
+        .as_ref(py)
+        .add_wrapped(wrap_pyfunction!(sleep_for))?;
+
+    let test_mod: PyObject =
+        PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?.into();
+
+    Ok(async move {
+        Python::with_gil(|py| {
+            pyo3_asyncio::into_future(
+                py,
+                test_mod
+                    .call_method1(py, "sleep_for_1s", (sleeper_mod.getattr(py, "sleep_for")?,))?
+                    .as_ref(py),
+            )
+        })?
+        .await?;
+        Ok(())
+    })
+}
+
+fn test_into_future(py: Python) -> PyResult<impl Future<Output = PyResult<()>> + Send + 'static> {
+    let test_mod: PyObject =
+        PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?.into();
+
+    Ok(async move {
+        Python::with_gil(|py| {
+            pyo3_asyncio::into_future(
+                py,
+                test_mod
+                    .call_method1(py, "py_sleep", (1.into_py(py),))?
+                    .as_ref(py),
+            )
+        })?
+        .await?;
+        Ok(())
+    })
+}
+
+fn test_async_sleep<'p>(
+    py: Python<'p>,
+) -> PyResult<impl Future<Output = PyResult<()>> + Send + 'static> {
+    let asyncio = PyObject::from(py.import("asyncio")?);
+
+    Ok(async move {
+        task::sleep(Duration::from_secs(1)).await;
+
+        Python::with_gil(|py| {
+            pyo3_asyncio::into_future(py, asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
+        })?
+        .await?;
+
+        Ok(())
+    })
+}
+
+fn test_blocking_sleep() {
+    thread::sleep(Duration::from_secs(1));
+}
+
+fn main() {
+    test_main(
+        "PyO3 Asyncio Test Suite",
+        vec![
+            Test::new_async(
+                "test_async_sleep".into(),
+                Python::with_gil(|py| {
+                    test_async_sleep(py)
+                        .map_err(|e| {
+                            e.print_and_set_sys_last_vars(py);
+                        })
+                        .unwrap()
+                }),
+            ),
+            new_sync_test("test_blocking_sleep".into(), || {
+                test_blocking_sleep();
+                Ok(())
+            }),
+            Test::new_async(
+                "test_into_coroutine".into(),
+                Python::with_gil(|py| {
+                    test_into_coroutine(py)
+                        .map_err(|e| {
+                            e.print_and_set_sys_last_vars(py);
+                        })
+                        .unwrap()
+                }),
+            ),
+            Test::new_async(
+                "test_into_future".into(),
+                Python::with_gil(|py| {
+                    test_into_future(py)
+                        .map_err(|e| {
+                            e.print_and_set_sys_last_vars(py);
+                        })
+                        .unwrap()
+                }),
+            ),
+        ],
+    )
+}

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+
+use pyo3::prelude::*;
+
+fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
+    move |e| {
+        // We can't display Python exceptions via std::fmt::Display,
+        // so print the error here manually.
+        e.print_and_set_sys_last_vars(py);
+    }
+}
+
+fn main() {
+    Python::with_gil(|py| {
+        pyo3_asyncio::with_runtime(py, || {
+            async_std::task::spawn(async move {
+                async_std::task::sleep(Duration::from_secs(1)).await;
+
+                Python::with_gil(|py| {
+                    let event_loop = pyo3_asyncio::get_event_loop(py);
+
+                    event_loop
+                        .call_method1(
+                            "call_soon_threadsafe",
+                            (event_loop.getattr("stop").map_err(dump_err(py)).unwrap(),),
+                        )
+                        .map_err(dump_err(py))
+                        .unwrap();
+                })
+            });
+
+            pyo3_asyncio::run_forever(py)?;
+
+            println!("test test_run_forever ... ok");
+            Ok(())
+        })
+        .map_err(dump_err(py))
+        .unwrap();
+    })
+}

--- a/pytests/test_tokio_asyncio.rs
+++ b/pytests/test_tokio_asyncio.rs
@@ -15,20 +15,11 @@ use pyo3_asyncio::{
     tokio::testing::{new_sync_test, test_main},
 };
 
-lazy_static! {
-    static ref CURRENT_THREAD_RUNTIME: Runtime = {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Couldn't build the runtime")
-    };
-}
-
 #[pyfunction]
 fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
     let secs = secs.extract()?;
 
-    pyo3_asyncio::tokio::into_coroutine(py, &CURRENT_THREAD_RUNTIME, async move {
+    pyo3_asyncio::tokio::into_coroutine(py, async move {
         tokio::time::sleep(Duration::from_secs(secs)).await;
         Python::with_gil(|py| Ok(py.None()))
     })
@@ -83,13 +74,8 @@ fn test_async_sleep<'p>(
 }
 
 fn main() {
-    thread::spawn(|| {
-        CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
-    });
-
     test_main(
         "PyO3 Asyncio Test Suite",
-        &CURRENT_THREAD_RUNTIME,
         vec![
             Test::new_async(
                 "test_async_sleep".into(),

--- a/pytests/test_tokio_asyncio.rs
+++ b/pytests/test_tokio_asyncio.rs
@@ -1,14 +1,8 @@
 mod common;
 
-use std::{
-    future::{pending, Future},
-    thread,
-    time::Duration,
-};
+use std::{future::Future, time::Duration};
 
-use lazy_static::lazy_static;
 use pyo3::{prelude::*, wrap_pyfunction};
-use tokio::runtime::{Builder, Runtime};
 
 use pyo3_asyncio::{
     testing::Test,

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -1,0 +1,8 @@
+mod common;
+mod tokio_asyncio;
+
+fn main() {
+    pyo3_asyncio::tokio::init_current_thread();
+
+    tokio_asyncio::test_main("PyO3 Asyncio Tokio Current-Thread Test Suite");
+}

--- a/pytests/test_tokio_current_thread_run_forever.rs
+++ b/pytests/test_tokio_current_thread_run_forever.rs
@@ -1,0 +1,7 @@
+mod tokio_run_forever;
+
+fn main() {
+    pyo3_asyncio::tokio::init_current_thread();
+
+    tokio_run_forever::test_main();
+}

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -1,0 +1,8 @@
+mod common;
+mod tokio_asyncio;
+
+fn main() {
+    pyo3_asyncio::tokio::init_multi_thread();
+
+    tokio_asyncio::test_main("PyO3 Asyncio Tokio Multi-Thread Test Suite");
+}

--- a/pytests/test_tokio_multi_thread_run_forever.rs
+++ b/pytests/test_tokio_multi_thread_run_forever.rs
@@ -1,0 +1,7 @@
+mod tokio_run_forever;
+
+fn main() {
+    pyo3_asyncio::tokio::init_multi_thread();
+
+    tokio_run_forever::test_main();
+}

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -1,13 +1,11 @@
-mod common;
-
 use std::{future::Future, time::Duration};
 
 use pyo3::{prelude::*, wrap_pyfunction};
 
-use pyo3_asyncio::{
-    testing::Test,
-    tokio::testing::{new_sync_test, test_main},
-};
+use pyo3_asyncio::{testing::Test, tokio::testing::new_sync_test};
+
+// enforce the inclusion of the common module
+use crate::common;
 
 #[pyfunction]
 fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
@@ -67,9 +65,9 @@ fn test_async_sleep<'p>(
     })
 }
 
-fn main() {
-    test_main(
-        "PyO3 Asyncio Test Suite",
+pub(super) fn test_main(suite_name: &str) {
+    pyo3_asyncio::tokio::testing::test_main(
+        suite_name,
         vec![
             Test::new_async(
                 "test_async_sleep".into(),

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -1,17 +1,6 @@
-use std::{future::pending, thread, time::Duration};
+use std::time::Duration;
 
-use lazy_static::lazy_static;
 use pyo3::prelude::*;
-use tokio::runtime::{Builder, Runtime};
-
-lazy_static! {
-    static ref CURRENT_THREAD_RUNTIME: Runtime = {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Couldn't build the runtime")
-    };
-}
 
 fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
     move |e| {
@@ -21,14 +10,10 @@ fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
     }
 }
 
-fn main() {
-    thread::spawn(|| {
-        CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
-    });
-
+pub(super) fn test_main() {
     Python::with_gil(|py| {
         pyo3_asyncio::with_runtime(py, || {
-            CURRENT_THREAD_RUNTIME.spawn(async move {
+            pyo3_asyncio::tokio::get_runtime().spawn(async move {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
                 Python::with_gil(|py| {

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -17,7 +17,6 @@
 //!
 //! `pytests/test_example.rs`
 //! ```no_run
-//!
 //! fn main() {
 //!
 //! }
@@ -96,7 +95,7 @@ use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
 /// The event loop runs until the given future is complete.
 ///
 /// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`run_forever`]
+/// [`crate::run_forever`]
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -265,6 +264,7 @@ where
     Ok(future_rx)
 }
 
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing Utilities for the async-std runtime.
 #[cfg(feature = "testing")]
 pub mod testing {
     use async_std::task;

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -1,0 +1,303 @@
+//! # PyO3 Asyncio Testing Utilities
+//!
+//! This module provides some utilities for parsing test arguments as well as running and filtering
+//! a sequence of tests.
+//!
+//! As mentioned [here](crate#pythons-event-loop), PyO3 Asyncio tests cannot use the default test
+//! harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
+//! provide our own test harness in order to create integration tests.
+//!
+//! ## Creating A PyO3 Asyncio Integration Test
+//!
+//! ### Main Test File
+//! First, we need to create the test's main file. Although these tests are considered integration
+//! tests, we cannot put them in the `tests` directory since that is a special directory owned by
+//! Cargo. Instead, we put our tests in a `pytests` directory, although the name `pytests` is just
+//! a convention.
+//!
+//! `pytests/test_example.rs`
+//! ```no_run
+//!
+//! fn main() {
+//!
+//! }
+//! ```
+//!
+//! ### Test Manifest Entry
+//! Next, we need to add our test file to the Cargo manifest. Add the following section to your
+//! `Cargo.toml`
+//!
+//! ```toml
+//! [[test]]
+//! name = "test_example"
+//! path = "pytests/test_example.rs"
+//! harness = false
+//! ```
+//!
+//! At this point you should be able to run the test via `cargo test`
+//!
+//! ### Using the PyO3 Asyncio Test Harness
+//! Now that we've got our test registered with `cargo test`, we can start using the PyO3 Asyncio
+//! test harness.
+//!
+//! In your `Cargo.toml` add the testing feature to `pyo3-asyncio`:
+//! ```toml
+//! pyo3-asyncio = { version = "0.13", features = ["testing", "async-std-runtime"] }
+//! ```
+//!
+//! Now, in your test's main file, call [`async_std::testing::test_main`]:
+//!
+//! ```no_run
+//! fn main() {
+//!     pyo3_asyncio::async_std::testing::test_main("Example Test Suite", vec![]);
+//! }
+//! ```
+//!
+//! ### Adding Tests to the PyO3 Asyncio Test Harness
+//!
+//! ```no_run
+//! use std::{time::Duration, thread};
+//!
+//! use pyo3_asyncio::testing::Test;
+//!
+//! fn main() {
+//!     pyo3_asyncio::async_std::testing::test_main(
+//!         "Example Test Suite",
+//!         vec![
+//!             Test::new_async(
+//!                 "test_async_sleep".into(),
+//!                 async move {
+//!                     async_std::task::sleep(Duration::from_secs(1)).await;
+//!                     Ok(())
+//!                 }
+//!             ),
+//!             pyo3_asyncio::async_std::testing::new_sync_test(
+//!                 "test_sync_sleep".into(),
+//!                 || {
+//!                     thread::sleep(Duration::from_secs(1));
+//!                     Ok(())
+//!                 }
+//!             )
+//!         ]
+//!     );
+//! }
+//! ```
+
+use std::future::Future;
+
+use async_std::task;
+use futures::channel::oneshot;
+use pyo3::prelude::*;
+
+use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+
+/// Run the event loop until the given Future completes
+///
+/// The event loop runs until the given future is complete.
+///
+/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
+/// [`run_forever`]
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The future to drive to completion
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// #
+/// # use pyo3::prelude::*;
+/// # use tokio::runtime::{Builder, Runtime};
+/// #
+/// # let runtime = Builder::new_current_thread()
+/// #     .enable_all()
+/// #     .build()
+/// #     .expect("Couldn't build the runtime");
+/// #
+/// # Python::with_gil(|py| {
+/// # pyo3_asyncio::with_runtime(py, || {
+/// pyo3_asyncio::tokio::run_until_complete(py, &runtime, async move {
+///     tokio::time::sleep(Duration::from_secs(1)).await;
+///     Ok(())
+/// })?;
+/// # Ok(())
+/// # })
+/// # .map_err(|e| {
+/// #    e.print_and_set_sys_last_vars(py);  
+/// # })
+/// # .unwrap();
+/// # });
+/// ```
+pub fn run_until_complete<F>(py: Python, fut: F) -> PyResult<()>
+where
+    F: Future<Output = PyResult<()>> + Send + 'static,
+{
+    let coro = into_coroutine(py, async move {
+        fut.await?;
+        Ok(Python::with_gil(|py| py.None()))
+    })?;
+
+    get_event_loop(py).call_method1("run_until_complete", (coro,))?;
+
+    Ok(())
+}
+
+#[pyclass]
+struct PyTaskCompleter {
+    tx: Option<oneshot::Sender<PyResult<PyObject>>>,
+}
+
+#[pymethods]
+impl PyTaskCompleter {
+    #[call]
+    #[args(task)]
+    pub fn __call__(&mut self, task: &PyAny) -> PyResult<()> {
+        debug_assert!(task.call_method0("done")?.extract()?);
+
+        let result = match task.call_method0("result") {
+            Ok(val) => Ok(val.into()),
+            Err(e) => Err(e),
+        };
+
+        // unclear to me whether or not this should be a panic or silent error.
+        //
+        // calling PyTaskCompleter twice should not be possible, but I don't think it really hurts
+        // anything if it happens.
+        if let Some(tx) = self.tx.take() {
+            if tx.send(result).is_err() {
+                // cancellation is not an error
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+    match result {
+        Ok(val) => {
+            let set_result = future.getattr("set_result")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_result, val))?;
+        }
+        Err(err) => {
+            let set_exception = future.getattr("set_exception")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_exception, err))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
+    move |e| {
+        // We can't display Python exceptions via std::fmt::Display,
+        // so print the error here manually.
+        e.print_and_set_sys_last_vars(py);
+    }
+}
+
+/// Convert a Rust Future into a Python coroutine
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+///
+/// use lazy_static::lazy_static;
+/// use pyo3::prelude::*;
+/// use tokio::runtime::{Builder, Runtime};
+///
+/// lazy_static! {
+///     static ref CURRENT_THREAD_RUNTIME: Runtime = {
+///         Builder::new_current_thread()
+///             .enable_all()
+///             .build()
+///             .expect("Couldn't build the runtime")
+///     };
+/// }
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
+///     let secs = secs.extract()?;
+///
+///     pyo3_asyncio::tokio::into_coroutine(py, &CURRENT_THREAD_RUNTIME, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///    })
+/// }
+/// ```
+pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).call0(py)?;
+    let future_tx1 = future_rx.clone();
+
+    task::spawn(async move {
+        task::spawn(async move {
+            let result = fut.await;
+
+            Python::with_gil(move |py| {
+                if set_result(py, future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py))
+                    .is_err()
+                {
+
+                    // Cancelled
+                }
+            });
+        })
+        .await;
+    });
+
+    Ok(future_rx)
+}
+
+#[cfg(feature = "testing")]
+pub mod testing {
+    use async_std::task;
+    use pyo3::prelude::*;
+
+    use crate::{
+        async_std::{dump_err, run_until_complete},
+        testing::{parse_args, test_harness, Test},
+        with_runtime,
+    };
+
+    /// Construct a test from a blocking function (like the traditional `#[test]` attribute)
+    pub fn new_sync_test<F>(name: String, func: F) -> Test
+    where
+        F: FnOnce() -> PyResult<()> + Send + 'static,
+    {
+        Test::new_async(name, async move { task::spawn_blocking(func).await })
+    }
+
+    /// Default main function for the test harness.
+    ///
+    /// This is meant to perform the necessary initialization for most test cases. If you want
+    /// additional control over the initialization (i.e. env_logger initialization), you can use this
+    /// function as a template.
+    pub fn test_main(suite_name: &str, tests: Vec<Test>) {
+        Python::with_gil(|py| {
+            with_runtime(py, || {
+                let args = parse_args(suite_name);
+                run_until_complete(py, test_harness(tests, args))?;
+                Ok(())
+            })
+            .map_err(dump_err(py))
+            .unwrap();
+        })
+    }
+}

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -149,7 +149,7 @@ pub mod testing {
     //! pyo3-asyncio = { version = "0.13", features = ["testing", "async-std-runtime"] }
     //! ```
     //!
-    //! Now, in your test's main file, call [`async_std::testing::test_main`]:
+    //! Now, in your test's main file, call [`crate::async_std::testing::test_main`]:
     //!
     //! ```no_run
     //! fn main() {
@@ -200,11 +200,10 @@ pub mod testing {
         Test::new_async(name, async move { task::spawn_blocking(func).await })
     }
 
-    /// Default main function for the test harness.
+    /// Default main function for the async-std test harness.
     ///
     /// This is meant to perform the necessary initialization for most test cases. If you want
-    /// additional control over the initialization (i.e. env_logger initialization), you can use this
-    /// function as a template.
+    /// additional control over the initialization, you can use this function as a template.
     pub fn test_main(suite_name: &str, tests: Vec<Test>) {
         generic::testing::test_main::<AsyncStdRuntime>(suite_name, tests)
     }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -13,20 +13,18 @@ pub trait JoinError {
 
 /// Generic Rust async/await runtime
 pub trait Runtime {
-    /// The type of errors that a JoinHandle can return after awaited
+    /// The error returned by a JoinHandle after being awaited
     type JoinError: JoinError + Send;
     /// A future that completes with the result of the spawned task
     type JoinHandle: Future<Output = Result<(), Self::JoinError>> + Send;
 
-    /// Spawn a function onto this runtime's event loop
+    /// Spawn a future onto this runtime's event loop
     fn spawn<F>(fut: F) -> Self::JoinHandle
     where
         F: Future<Output = ()> + Send + 'static;
 }
 
 /// Run the event loop until the given Future completes
-///
-/// The event loop runs until the given future is complete.
 ///
 /// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
 /// [`crate::run_forever`]
@@ -264,7 +262,7 @@ where
     Ok(future_rx)
 }
 
-/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing Utilities for the Tokio runtime.
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing utilities for generic runtimes.
 #[cfg(feature = "testing")]
 pub mod testing {
     use pyo3::prelude::*;
@@ -276,10 +274,10 @@ pub mod testing {
         with_runtime,
     };
 
-    /// Default main function for the test harness.
+    /// Default main function for the generic test harness.
     ///
     /// This is meant to perform the necessary initialization for most test cases. If you want
-    /// additional control over the initialization (i.e. env_logger initialization), you can use this
+    /// additional control over the initialization, you can use this
     /// function as a template.
     pub fn test_main<R>(suite_name: &str, tests: Vec<Test>)
     where

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,299 @@
+use std::future::Future;
+
+use futures::channel::oneshot;
+use pyo3::{exceptions::PyException, prelude::*};
+
+use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+
+pub trait JoinError {
+    fn is_panic(&self) -> bool;
+}
+
+pub trait Runtime {
+    type JoinError: JoinError + Send;
+    type JoinHandle: Future<Output = Result<(), Self::JoinError>> + Send;
+
+    fn spawn<F>(fut: F) -> Self::JoinHandle
+    where
+        F: Future<Output = ()> + Send + 'static;
+}
+
+/// Run the event loop until the given Future completes
+///
+/// The event loop runs until the given future is complete.
+///
+/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
+/// [`crate::run_forever`]
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The future to drive to completion
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # use std::time::Duration;
+/// #
+/// # use pyo3::prelude::*;
+/// #
+/// # Python::with_gil(|py| {
+/// # pyo3_asyncio::with_runtime(py, || {
+/// pyo3_asyncio::generic::run_until_complete::<MyCustomRuntime, _>(py, async move {
+///     tokio::time::sleep(Duration::from_secs(1)).await;
+///     Ok(())
+/// })?;
+/// # Ok(())
+/// # })
+/// # .map_err(|e| {
+/// #    e.print_and_set_sys_last_vars(py);  
+/// # })
+/// # .unwrap();
+/// # });
+/// ```
+pub fn run_until_complete<R, F>(py: Python, fut: F) -> PyResult<()>
+where
+    R: Runtime,
+    F: Future<Output = PyResult<()>> + Send + 'static,
+{
+    let coro = into_coroutine::<R, _>(py, async move {
+        fut.await?;
+        Ok(Python::with_gil(|py| py.None()))
+    })?;
+
+    get_event_loop(py).call_method1("run_until_complete", (coro,))?;
+
+    Ok(())
+}
+
+#[pyclass]
+struct PyTaskCompleter {
+    tx: Option<oneshot::Sender<PyResult<PyObject>>>,
+}
+
+#[pymethods]
+impl PyTaskCompleter {
+    #[call]
+    #[args(task)]
+    pub fn __call__(&mut self, task: &PyAny) -> PyResult<()> {
+        debug_assert!(task.call_method0("done")?.extract()?);
+
+        let result = match task.call_method0("result") {
+            Ok(val) => Ok(val.into()),
+            Err(e) => Err(e),
+        };
+
+        // unclear to me whether or not this should be a panic or silent error.
+        //
+        // calling PyTaskCompleter twice should not be possible, but I don't think it really hurts
+        // anything if it happens.
+        if let Some(tx) = self.tx.take() {
+            if tx.send(result).is_err() {
+                // cancellation is not an error
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+    match result {
+        Ok(val) => {
+            let set_result = future.getattr("set_result")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_result, val))?;
+        }
+        Err(err) => {
+            let set_exception = future.getattr("set_exception")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_exception, err))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
+    move |e| {
+        // We can't display Python exceptions via std::fmt::Display,
+        // so print the error here manually.
+        e.print_and_set_sys_last_vars(py);
+    }
+}
+
+/// Convert a Rust Future into a Python coroutine with a generic runtime
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
+///     let secs = secs.extract()?;
+///
+///     pyo3_asyncio::generic::into_coroutine::<MyCustomRuntime, _>(py, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///    })
+/// }
+/// ```
+pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
+where
+    R: Runtime,
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).call0(py)?;
+    let future_tx1 = future_rx.clone();
+    let future_tx2 = future_rx.clone();
+
+    R::spawn(async move {
+        if let Err(e) = R::spawn(async move {
+            let result = fut.await;
+
+            Python::with_gil(move |py| {
+                if set_result(py, future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py))
+                    .is_err()
+                {
+
+                    // Cancelled
+                }
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if set_result(
+                        py,
+                        future_tx2.as_ref(py),
+                        Err(PyException::new_err("rust future panicked")),
+                    )
+                    .map_err(dump_err(py))
+                    .is_err()
+                    {
+                        // Cancelled
+                    }
+                });
+            }
+        }
+    });
+
+    Ok(future_rx)
+}
+
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing Utilities for the Tokio runtime.
+#[cfg(feature = "testing")]
+pub mod testing {
+    use pyo3::prelude::*;
+
+    use crate::{
+        generic::{dump_err, run_until_complete, Runtime},
+        testing::{parse_args, test_harness, Test},
+        with_runtime,
+    };
+
+    /// Default main function for the test harness.
+    ///
+    /// This is meant to perform the necessary initialization for most test cases. If you want
+    /// additional control over the initialization (i.e. env_logger initialization), you can use this
+    /// function as a template.
+    pub fn test_main<R>(suite_name: &str, tests: Vec<Test>)
+    where
+        R: Runtime,
+    {
+        Python::with_gil(|py| {
+            with_runtime(py, || {
+                let args = parse_args(suite_name);
+                run_until_complete::<R, _>(py, test_harness(tests, args))?;
+                Ok(())
+            })
+            .map_err(dump_err(py))
+            .unwrap();
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! Python's coroutines cannot be directly spawned on a Rust event loop. The two coroutine models
 //! require some additional assistance from their event loops, so in all likelihood they will need
 //! a new _unique_ event loop that addresses the needs of both languages if the coroutines are to
-//! be run on the same event loop.
+//! be run on the same loop.
 //!
 //! It's not immediately clear that this would provide worthwhile performance wins either, so in the
 //! interest of keeping things simple, this crate creates and manages the Python event loop and
@@ -218,8 +218,8 @@ pub fn get_event_loop(py: Python) -> &PyAny {
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
 /// // Wait 1 second, then stop the event loop
-/// tokio::spawn(async move {
-///     tokio::time::sleep(Duration::from_secs(1)).await;
+/// async_std::task::spawn(async move {
+///     async_std::task::sleep(Duration::from_secs(1)).await;
 ///     Python::with_gil(|py| {
 ///         let event_loop = pyo3_asyncio::get_event_loop(py);
 ///         

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub mod async_std;
 #[doc(inline)]
 pub mod tokio;
 
+/// Generic implementations of PyO3 Asyncio utilities that can be used for any Rust runtime
 pub mod generic;
 
 use std::future::Future;
@@ -371,4 +372,12 @@ pub fn into_future(
             }),
         }
     })
+}
+
+fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
+    move |e| {
+        // We can't display Python exceptions via std::fmt::Display,
+        // so print the error here manually.
+        e.print_and_set_sys_last_vars(py);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ pub mod async_std;
 #[doc(inline)]
 pub mod tokio;
 
+pub mod generic;
+
 use std::future::Future;
 
 use futures::channel::oneshot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@
 //! be run on the same event loop.
 //!
 //! It's not immediately clear that this would provide worthwhile performance wins either, so in the
-//! interest of keeping things simple, this crate runs both event loops independently and handles
-//! the communication between them.
+//! interest of keeping things simple, this crate creates and manages the Python event loop and
+//! handles the communication between separate Rust event loops.
 //!
 //! ## Python's Event Loop
 //!
@@ -30,13 +30,37 @@
 //!
 //! ## Rust's Event Loop
 //!
-//! Currently only the Tokio runtime is supported by this crate. Tokio makes it easy to construct
-//! and maintain a runtime that runs on background threads only and it provides a single threaded
-//! scheduler to make it easier to work around Python's GIL.
+//! Currently only the async-std and Tokio runtimes are supported by this crate.
 //!
 //! > _In the future, more runtimes may be supported for Rust._
 //!
 //! ## Features
+//!
+//! Items marked with
+//! <span
+//!   class="module-item stab portability"
+//!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
+//! ><code>async-std-runtime</code></span>
+//! are only available when the `async-std-runtime` Cargo feature is enabled:
+//!
+//! ```toml
+//! [dependencies.pyo3-asyncio]
+//! version = "0.13.0"
+//! features = ["async-std-runtime"]
+//! ```
+//!
+//! Items marked with
+//! <span
+//!   class="module-item stab portability"
+//!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
+//! ><code>tokio-runtime</code></span>
+//! are only available when the `tokio-runtime` Cargo feature is enabled:
+//!
+//! ```toml
+//! [dependencies.pyo3-asyncio]
+//! version = "0.13.0"
+//! features = ["tokio-runtime"]
+//! ```
 //!
 //! Items marked with
 //! <span
@@ -56,10 +80,12 @@
 #[doc(inline)]
 pub mod testing;
 
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>async-std-runtime</code></span> PyO3 Asyncio functions specific to the async-std runtime
 #[cfg(feature = "async-std")]
 #[doc(inline)]
 pub mod async_std;
 
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>tokio-runtime</code></span> PyO3 Asyncio functions specific to the tokio runtime
 #[cfg(feature = "tokio-runtime")]
 #[doc(inline)]
 pub mod tokio;
@@ -172,11 +198,11 @@ pub fn get_event_loop(py: Python) -> &PyAny {
 
 /// Run the event loop forever
 ///
-/// This can be called instead of [`run_until_complete`] to run the event loop
+/// This can be called instead of `run_until_complete` to run the event loop
 /// until `stop` is called rather than driving a future to completion.
 ///
-/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`run_forever`]
+/// After this function returns, the event loop can be resumed with either `run_until_complete` or
+/// [`crate::run_forever`]
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -3,6 +3,10 @@
 //! This module provides some utilities for parsing test arguments as well as running and filtering
 //! a sequence of tests.
 //!
+//! > These utilities are completely independent of the runtime being used. To
+//! > get a more complete picture of how to run tests for PyO3 Asyncio applications, see
+//! > [`crate::async_std::testing`] or [`crate::tokio::testing`] for more details.
+//!
 //! As mentioned [here](crate#pythons-event-loop), PyO3 Asyncio tests cannot use the default test
 //! harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
 //! provide our own test harness in order to create integration tests.

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,0 +1,355 @@
+//! # PyO3 Asyncio Testing Utilities
+//!
+//! This module provides some utilities for parsing test arguments as well as running and filtering
+//! a sequence of tests.
+//!
+//! As mentioned [here](crate#pythons-event-loop), PyO3 Asyncio tests cannot use the default test
+//! harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
+//! provide our own test harness in order to create integration tests.
+//!
+//! ## Creating A PyO3 Asyncio Integration Test
+//!
+//! ### Main Test File
+//! First, we need to create the test's main file. Although these tests are considered integration
+//! tests, we cannot put them in the `tests` directory since that is a special directory owned by
+//! Cargo. Instead, we put our tests in a `pytests` directory, although the name `pytests` is just
+//! a convention.
+//!
+//! `pytests/test_example.rs`
+//! ```no_run
+//!
+//! fn main() {
+//!
+//! }
+//! ```
+//!
+//! ### Test Manifest Entry
+//! Next, we need to add our test file to the Cargo manifest. Add the following section to your
+//! `Cargo.toml`
+//!
+//! ```toml
+//! [[test]]
+//! name = "test_example"
+//! path = "pytests/test_example.rs"
+//! harness = false
+//! ```
+//!
+//! At this point you should be able to run the test via `cargo test`
+//!
+//! ### Using the PyO3 Asyncio Test Harness
+//! Now that we've got our test registered with `cargo test`, we can start using the PyO3 Asyncio
+//! test harness.
+//!
+//! In your `Cargo.toml` add the testing feature to `pyo3-asyncio`:
+//! ```toml
+//! pyo3-asyncio = { version = "0.13", features = ["testing", "tokio-runtime"] }
+//! ```
+//!
+//! Now, in your test's main file, call [`crate::tokio::testing::test_main`]:
+//!
+//! ```no_run
+//! use std::{future::pending, thread};
+//!
+//! use lazy_static::lazy_static;
+//! use tokio::runtime::{Builder, Runtime};
+//!
+//! lazy_static! {
+//!     static ref CURRENT_THREAD_RUNTIME: Runtime = {
+//!         Builder::new_current_thread()
+//!             .enable_all()
+//!             .build()
+//!             .expect("Couldn't build the runtime")
+//!     };
+//! }
+//!
+//! fn main() {
+//!     thread::spawn(|| {
+//!         CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
+//!     });
+//!
+//!     pyo3_asyncio::tokio::testing::test_main(
+//!         "Example Test Suite", &CURRENT_THREAD_RUNTIME, vec![]
+//!     );
+//! }
+//! ```
+//!
+//! ### Adding Tests to the PyO3 Asyncio Test Harness
+//!
+//! ```no_run
+//! use std::{thread, future::pending, time::Duration};
+//!
+//! use lazy_static::lazy_static;
+//! use pyo3_asyncio::testing::Test;
+//! use tokio::runtime::{Builder, Runtime};
+//!
+//! lazy_static! {
+//!     static ref CURRENT_THREAD_RUNTIME: Runtime = {
+//!         Builder::new_current_thread()
+//!             .enable_all()
+//!             .build()
+//!             .expect("Couldn't build the runtime")
+//!     };
+//! }
+//!
+//! fn main() {
+//!     thread::spawn(|| {
+//!         CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
+//!     });
+//!
+//!     pyo3_asyncio::tokio::testing::test_main(
+//!         "Example Test Suite",
+//!         &CURRENT_THREAD_RUNTIME,
+//!         vec![
+//!             Test::new_async(
+//!                 "test_async_sleep".into(),
+//!                 async move {
+//!                     tokio::time::sleep(Duration::from_secs(1)).await;
+//!                     Ok(())
+//!                 }
+//!             ),
+//!             pyo3_asyncio::tokio::testing::new_sync_test("test_sync_sleep".into(), || {
+//!                 thread::sleep(Duration::from_secs(1));
+//!                 Ok(())
+//!             })
+//!         ]
+//!     );
+//! }
+//! ```
+
+use std::future::Future;
+
+use ::tokio::runtime::Runtime;
+use futures::channel::oneshot;
+use pyo3::{exceptions::PyException, prelude::*};
+
+use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+
+/// Run the event loop until the given Future completes
+///
+/// The event loop runs until the given future is complete.
+///
+/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
+/// [`run_forever`]
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The future to drive to completion
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// #
+/// # use pyo3::prelude::*;
+/// # use tokio::runtime::{Builder, Runtime};
+/// #
+/// # let runtime = Builder::new_current_thread()
+/// #     .enable_all()
+/// #     .build()
+/// #     .expect("Couldn't build the runtime");
+/// #
+/// # Python::with_gil(|py| {
+/// # pyo3_asyncio::with_runtime(py, || {
+/// pyo3_asyncio::tokio::run_until_complete(py, &runtime, async move {
+///     tokio::time::sleep(Duration::from_secs(1)).await;
+///     Ok(())
+/// })?;
+/// # Ok(())
+/// # })
+/// # .map_err(|e| {
+/// #    e.print_and_set_sys_last_vars(py);  
+/// # })
+/// # .unwrap();
+/// # });
+/// ```
+pub fn run_until_complete<F>(py: Python, runtime: &Runtime, fut: F) -> PyResult<()>
+where
+    F: Future<Output = PyResult<()>> + Send + 'static,
+{
+    let coro = into_coroutine(py, runtime, async move {
+        fut.await?;
+        Ok(Python::with_gil(|py| py.None()))
+    })?;
+
+    get_event_loop(py).call_method1("run_until_complete", (coro,))?;
+
+    Ok(())
+}
+
+#[pyclass]
+struct PyTaskCompleter {
+    tx: Option<oneshot::Sender<PyResult<PyObject>>>,
+}
+
+#[pymethods]
+impl PyTaskCompleter {
+    #[call]
+    #[args(task)]
+    pub fn __call__(&mut self, task: &PyAny) -> PyResult<()> {
+        debug_assert!(task.call_method0("done")?.extract()?);
+
+        let result = match task.call_method0("result") {
+            Ok(val) => Ok(val.into()),
+            Err(e) => Err(e),
+        };
+
+        // unclear to me whether or not this should be a panic or silent error.
+        //
+        // calling PyTaskCompleter twice should not be possible, but I don't think it really hurts
+        // anything if it happens.
+        if let Some(tx) = self.tx.take() {
+            if tx.send(result).is_err() {
+                // cancellation is not an error
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+    match result {
+        Ok(val) => {
+            let set_result = future.getattr("set_result")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_result, val))?;
+        }
+        Err(err) => {
+            let set_exception = future.getattr("set_exception")?;
+            CALL_SOON
+                .get()
+                .expect(EXPECT_INIT)
+                .call1(py, (set_exception, err))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
+    move |e| {
+        // We can't display Python exceptions via std::fmt::Display,
+        // so print the error here manually.
+        e.print_and_set_sys_last_vars(py);
+    }
+}
+
+/// Convert a Rust Future into a Python coroutine
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+///
+/// use lazy_static::lazy_static;
+/// use pyo3::prelude::*;
+/// use tokio::runtime::{Builder, Runtime};
+///
+/// lazy_static! {
+///     static ref CURRENT_THREAD_RUNTIME: Runtime = {
+///         Builder::new_current_thread()
+///             .enable_all()
+///             .build()
+///             .expect("Couldn't build the runtime")
+///     };
+/// }
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
+///     let secs = secs.extract()?;
+///
+///     pyo3_asyncio::tokio::into_coroutine(py, &CURRENT_THREAD_RUNTIME, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///    })
+/// }
+/// ```
+pub fn into_coroutine<F>(py: Python, runtime: &Runtime, fut: F) -> PyResult<PyObject>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).call0(py)?;
+    let future_tx1 = future_rx.clone();
+    let future_tx2 = future_rx.clone();
+
+    runtime.spawn(async move {
+        if let Err(e) = ::tokio::spawn(async move {
+            let result = fut.await;
+
+            Python::with_gil(move |py| {
+                if set_result(py, future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py))
+                    .is_err()
+                {
+
+                    // Cancelled
+                }
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if set_result(
+                        py,
+                        future_tx2.as_ref(py),
+                        Err(PyException::new_err("rust future panicked")),
+                    )
+                    .map_err(dump_err(py))
+                    .is_err()
+                    {
+                        // Cancelled
+                    }
+                });
+            }
+        }
+    });
+
+    Ok(future_rx)
+}
+
+#[cfg(feature = "testing")]
+pub mod testing {
+    use ::tokio::runtime::Runtime;
+    use pyo3::prelude::*;
+
+    use crate::{
+        testing::{parse_args, test_harness, Test},
+        tokio::{dump_err, run_until_complete},
+        with_runtime,
+    };
+
+    /// Construct a test from a blocking function (like the traditional `#[test]` attribute)
+    pub fn new_sync_test<F>(name: String, func: F) -> Test
+    where
+        F: FnOnce() -> PyResult<()> + Send + 'static,
+    {
+        Test::new_async(name, async move {
+            ::tokio::task::spawn_blocking(func).await.unwrap()
+        })
+    }
+
+    /// Default main function for the test harness.
+    ///
+    /// This is meant to perform the necessary initialization for most test cases. If you want
+    /// additional control over the initialization (i.e. env_logger initialization), you can use this
+    /// function as a template.
+    pub fn test_main(suite_name: &str, runtime: &Runtime, tests: Vec<Test>) {
+        Python::with_gil(|py| {
+            with_runtime(py, || {
+                let args = parse_args(suite_name);
+                run_until_complete(py, runtime, test_harness(tests, args))?;
+                Ok(())
+            })
+            .map_err(dump_err(py))
+            .unwrap();
+        })
+    }
+}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -17,7 +17,6 @@
 //!
 //! `pytests/test_example.rs`
 //! ```no_run
-//!
 //! fn main() {
 //!
 //! }
@@ -129,7 +128,7 @@ use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
 /// The event loop runs until the given future is complete.
 ///
 /// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`run_forever`]
+/// [`crate::run_forever`]
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -315,6 +314,7 @@ where
     Ok(future_rx)
 }
 
+/// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing Utilities for the Tokio runtime.
 #[cfg(feature = "testing")]
 pub mod testing {
     use ::tokio::runtime::Runtime;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -100,7 +100,7 @@ pub fn init_multi_thread() {
 /// #
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
-/// pyo3_asyncio::tokio::init_current_thread();
+/// # pyo3_asyncio::tokio::init_current_thread();
 /// pyo3_asyncio::tokio::run_until_complete(py, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
@@ -199,10 +199,13 @@ where
 /// pyo3-asyncio = { version = "0.13", features = ["testing", "tokio-runtime"] }
 /// ```
 ///
-/// Now, in your test's main file, call [`crate::tokio::testing::test_main`]:
+/// Now, in your test's main file, initialize the tokio runtime and call
+/// [`crate::tokio::testing::test_main`]:
 ///
 /// ```no_run
 /// fn main() {
+///     pyo3_asyncio::tokio::init_current_thread();
+///
 ///     pyo3_asyncio::tokio::testing::test_main("Example Test Suite", vec![]);
 /// }
 /// ```
@@ -215,6 +218,8 @@ where
 /// use pyo3_asyncio::testing::Test;
 ///
 /// fn main() {
+///     pyo3_asyncio::tokio::init_current_thread();
+///
 ///     pyo3_asyncio::tokio::testing::test_main(
 ///         "Example Test Suite",
 ///         vec![
@@ -259,7 +264,7 @@ pub mod testing {
     /// additional control over the initialization (i.e. env_logger initialization), you can use this
     /// function as a template.
     ///
-    /// Note: The tokio runtime must be initialized before calling this function!
+    /// > _The tokio runtime must be initialized before calling this function!_
     pub fn test_main(suite_name: &str, tests: Vec<Test>) {
         Python::with_gil(|py| {
             with_runtime(py, || {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,127 +1,55 @@
-//! # PyO3 Asyncio Testing Utilities
-//!
-//! This module provides some utilities for parsing test arguments as well as running and filtering
-//! a sequence of tests.
-//!
-//! As mentioned [here](crate#pythons-event-loop), PyO3 Asyncio tests cannot use the default test
-//! harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
-//! provide our own test harness in order to create integration tests.
-//!
-//! ## Creating A PyO3 Asyncio Integration Test
-//!
-//! ### Main Test File
-//! First, we need to create the test's main file. Although these tests are considered integration
-//! tests, we cannot put them in the `tests` directory since that is a special directory owned by
-//! Cargo. Instead, we put our tests in a `pytests` directory, although the name `pytests` is just
-//! a convention.
-//!
-//! `pytests/test_example.rs`
-//! ```no_run
-//! fn main() {
-//!
-//! }
-//! ```
-//!
-//! ### Test Manifest Entry
-//! Next, we need to add our test file to the Cargo manifest. Add the following section to your
-//! `Cargo.toml`
-//!
-//! ```toml
-//! [[test]]
-//! name = "test_example"
-//! path = "pytests/test_example.rs"
-//! harness = false
-//! ```
-//!
-//! At this point you should be able to run the test via `cargo test`
-//!
-//! ### Using the PyO3 Asyncio Test Harness
-//! Now that we've got our test registered with `cargo test`, we can start using the PyO3 Asyncio
-//! test harness.
-//!
-//! In your `Cargo.toml` add the testing feature to `pyo3-asyncio`:
-//! ```toml
-//! pyo3-asyncio = { version = "0.13", features = ["testing", "tokio-runtime"] }
-//! ```
-//!
-//! Now, in your test's main file, call [`crate::tokio::testing::test_main`]:
-//!
-//! ```no_run
-//! use std::{future::pending, thread};
-//!
-//! use lazy_static::lazy_static;
-//! use tokio::runtime::{Builder, Runtime};
-//!
-//! lazy_static! {
-//!     static ref CURRENT_THREAD_RUNTIME: Runtime = {
-//!         Builder::new_current_thread()
-//!             .enable_all()
-//!             .build()
-//!             .expect("Couldn't build the runtime")
-//!     };
-//! }
-//!
-//! fn main() {
-//!     thread::spawn(|| {
-//!         CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
-//!     });
-//!
-//!     pyo3_asyncio::tokio::testing::test_main(
-//!         "Example Test Suite", &CURRENT_THREAD_RUNTIME, vec![]
-//!     );
-//! }
-//! ```
-//!
-//! ### Adding Tests to the PyO3 Asyncio Test Harness
-//!
-//! ```no_run
-//! use std::{thread, future::pending, time::Duration};
-//!
-//! use lazy_static::lazy_static;
-//! use pyo3_asyncio::testing::Test;
-//! use tokio::runtime::{Builder, Runtime};
-//!
-//! lazy_static! {
-//!     static ref CURRENT_THREAD_RUNTIME: Runtime = {
-//!         Builder::new_current_thread()
-//!             .enable_all()
-//!             .build()
-//!             .expect("Couldn't build the runtime")
-//!     };
-//! }
-//!
-//! fn main() {
-//!     thread::spawn(|| {
-//!         CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
-//!     });
-//!
-//!     pyo3_asyncio::tokio::testing::test_main(
-//!         "Example Test Suite",
-//!         &CURRENT_THREAD_RUNTIME,
-//!         vec![
-//!             Test::new_async(
-//!                 "test_async_sleep".into(),
-//!                 async move {
-//!                     tokio::time::sleep(Duration::from_secs(1)).await;
-//!                     Ok(())
-//!                 }
-//!             ),
-//!             pyo3_asyncio::tokio::testing::new_sync_test("test_sync_sleep".into(), || {
-//!                 thread::sleep(Duration::from_secs(1));
-//!                 Ok(())
-//!             })
-//!         ]
-//!     );
-//! }
-//! ```
+use std::{
+    future::{pending, Future},
+    thread,
+};
 
-use std::future::Future;
-
-use ::tokio::runtime::Runtime;
+use ::tokio::{
+    runtime::{Builder, Runtime},
+    task,
+};
 use futures::channel::oneshot;
-use pyo3::{exceptions::PyException, prelude::*};
+use lazy_static::lazy_static;
+use pyo3::prelude::*;
 
-use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+use crate::{generic, CALL_SOON, EXPECT_INIT};
+
+lazy_static! {
+    static ref CURRENT_THREAD_RUNTIME: Runtime = {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Couldn't build the runtime")
+    };
+}
+
+impl generic::JoinError for task::JoinError {
+    fn is_panic(&self) -> bool {
+        task::JoinError::is_panic(self)
+    }
+}
+
+struct TokioRuntime;
+
+impl generic::Runtime for TokioRuntime {
+    type JoinError = task::JoinError;
+    type JoinHandle = task::JoinHandle<()>;
+
+    fn spawn<F>(fut: F) -> Self::JoinHandle
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        CURRENT_THREAD_RUNTIME.spawn(async move {
+            fut.await;
+        })
+    }
+}
+
+/// Initialize the Tokio Runtime
+pub fn init() {
+    thread::spawn(|| {
+        CURRENT_THREAD_RUNTIME.block_on(pending::<()>());
+    });
+}
 
 /// Run the event loop until the given Future completes
 ///
@@ -149,7 +77,8 @@ use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
 /// #
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
-/// pyo3_asyncio::tokio::run_until_complete(py, &runtime, async move {
+/// pyo3_asyncio::tokio::init();
+/// pyo3_asyncio::tokio::run_until_complete(py, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
 /// })?;
@@ -161,18 +90,11 @@ use crate::{get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
 /// # .unwrap();
 /// # });
 /// ```
-pub fn run_until_complete<F>(py: Python, runtime: &Runtime, fut: F) -> PyResult<()>
+pub fn run_until_complete<F>(py: Python, fut: F) -> PyResult<()>
 where
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let coro = into_coroutine(py, runtime, async move {
-        fut.await?;
-        Ok(Python::with_gil(|py| py.None()))
-    })?;
-
-    get_event_loop(py).call_method1("run_until_complete", (coro,))?;
-
-    Ok(())
+    generic::run_until_complete::<TokioRuntime, _>(py, fut)
 }
 
 #[pyclass]
@@ -246,83 +168,115 @@ fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
 /// ```no_run
 /// use std::time::Duration;
 ///
-/// use lazy_static::lazy_static;
 /// use pyo3::prelude::*;
-/// use tokio::runtime::{Builder, Runtime};
-///
-/// lazy_static! {
-///     static ref CURRENT_THREAD_RUNTIME: Runtime = {
-///         Builder::new_current_thread()
-///             .enable_all()
-///             .build()
-///             .expect("Couldn't build the runtime")
-///     };
-/// }
 ///
 /// /// Awaitable sleep function
 /// #[pyfunction]
 /// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
 ///     let secs = secs.extract()?;
 ///
-///     pyo3_asyncio::tokio::into_coroutine(py, &CURRENT_THREAD_RUNTIME, async move {
+///     pyo3_asyncio::tokio::into_coroutine(py, async move {
 ///         tokio::time::sleep(Duration::from_secs(secs)).await;
 ///         Python::with_gil(|py| Ok(py.None()))
 ///    })
 /// }
 /// ```
-pub fn into_coroutine<F>(py: Python, runtime: &Runtime, fut: F) -> PyResult<PyObject>
+pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).call0(py)?;
-    let future_tx1 = future_rx.clone();
-    let future_tx2 = future_rx.clone();
-
-    runtime.spawn(async move {
-        if let Err(e) = ::tokio::spawn(async move {
-            let result = fut.await;
-
-            Python::with_gil(move |py| {
-                if set_result(py, future_tx1.as_ref(py), result)
-                    .map_err(dump_err(py))
-                    .is_err()
-                {
-
-                    // Cancelled
-                }
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::with_gil(move |py| {
-                    if set_result(
-                        py,
-                        future_tx2.as_ref(py),
-                        Err(PyException::new_err("rust future panicked")),
-                    )
-                    .map_err(dump_err(py))
-                    .is_err()
-                    {
-                        // Cancelled
-                    }
-                });
-            }
-        }
-    });
-
-    Ok(future_rx)
+    generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Testing Utilities for the Tokio runtime.
+///
+// # PyO3 Asyncio Testing Utilities
+///
+/// This module provides some utilities for parsing test arguments as well as running and filtering
+/// a sequence of tests.
+///
+/// As mentioned [here](crate#pythons-event-loop), PyO3 Asyncio tests cannot use the default test
+/// harness since it doesn't allow Python to gain control over the main thread. Instead, we have to
+/// provide our own test harness in order to create integration tests.
+///
+/// ## Creating A PyO3 Asyncio Integration Test
+///
+/// ### Main Test File
+/// First, we need to create the test's main file. Although these tests are considered integration
+/// tests, we cannot put them in the `tests` directory since that is a special directory owned by
+/// Cargo. Instead, we put our tests in a `pytests` directory, although the name `pytests` is just
+/// a convention.
+///
+/// `pytests/test_example.rs`
+/// ```no_run
+/// fn main() {
+///
+/// }
+/// ```
+///
+/// ### Test Manifest Entry
+/// Next, we need to add our test file to the Cargo manifest. Add the following section to your
+/// `Cargo.toml`
+///
+/// ```toml
+/// [[test]]
+/// name = "test_example"
+/// path = "pytests/test_example.rs"
+/// harness = false
+/// ```
+///
+/// At this point you should be able to run the test via `cargo test`
+///
+/// ### Using the PyO3 Asyncio Test Harness
+/// Now that we've got our test registered with `cargo test`, we can start using the PyO3 Asyncio
+/// test harness.
+///
+/// In your `Cargo.toml` add the testing feature to `pyo3-asyncio`:
+/// ```toml
+/// pyo3-asyncio = { version = "0.13", features = ["testing", "tokio-runtime"] }
+/// ```
+///
+/// Now, in your test's main file, call [`crate::tokio::testing::test_main`]:
+///
+/// ```no_run
+/// fn main() {
+///     pyo3_asyncio::tokio::testing::test_main("Example Test Suite", vec![]);
+/// }
+/// ```
+///
+/// ### Adding Tests to the PyO3 Asyncio Test Harness
+///
+/// ```no_run
+/// use std::{thread, time::Duration};
+///
+/// use pyo3_asyncio::testing::Test;
+///
+/// fn main() {
+///     pyo3_asyncio::tokio::testing::test_main(
+///         "Example Test Suite",
+///         vec![
+///             Test::new_async(
+///                 "test_async_sleep".into(),
+///                 async move {
+///                     tokio::time::sleep(Duration::from_secs(1)).await;
+///                     Ok(())
+///                 }
+///             ),
+///             pyo3_asyncio::tokio::testing::new_sync_test("test_sync_sleep".into(), || {
+///                 thread::sleep(Duration::from_secs(1));
+///                 Ok(())
+///             })
+///         ]
+///     );
+/// }
+/// ```
 #[cfg(feature = "testing")]
 pub mod testing {
-    use ::tokio::runtime::Runtime;
     use pyo3::prelude::*;
 
     use crate::{
         testing::{parse_args, test_harness, Test},
-        tokio::{dump_err, run_until_complete},
+        tokio::dump_err,
         with_runtime,
     };
 
@@ -341,11 +295,13 @@ pub mod testing {
     /// This is meant to perform the necessary initialization for most test cases. If you want
     /// additional control over the initialization (i.e. env_logger initialization), you can use this
     /// function as a template.
-    pub fn test_main(suite_name: &str, runtime: &Runtime, tests: Vec<Test>) {
+    pub fn test_main(suite_name: &str, tests: Vec<Test>) {
         Python::with_gil(|py| {
             with_runtime(py, || {
                 let args = parse_args(suite_name);
-                run_until_complete(py, runtime, test_harness(tests, args))?;
+                crate::tokio::init();
+                crate::tokio::run_until_complete(py, test_harness(tests, args))?;
+
                 Ok(())
             })
             .map_err(dump_err(py))


### PR DESCRIPTION
Attempt at moving tokio-specific stuff into a feature-gated submodule as well as adding support for another popular runtime: async-std.

These changes remove the `spawn` and `spawn_blocking` functions from the API and add two new submodules for separate implementations for runtime-specific functions such as `into_coroutine` and `run_until_complete`. The intent here is to move away from `pyo3-asyncio` acting as the central rust runtime with tokio abstracted away and instead provide functions that work with any rust runtime.