### PR TITLE
Naming changes for #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
 
 ```rust
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::async_std::main]
@@ -37,7 +39,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     fut.await?;
@@ -50,6 +52,8 @@ The same application can be written to use `tokio` instead using the `#[pyo3_asy
 attribute.
 
 ```rust
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::tokio::main]
@@ -58,7 +62,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     fut.await?;

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
 
 ```rust no_run
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 fn main() {
@@ -41,8 +43,7 @@ fn main() {
             pyo3_asyncio::async_std::run_until_complete(py, async move {
                 Python::with_gil(|py| {
                     // convert asyncio.sleep into a Rust Future
-                    pyo3_asyncio::into_future(
-                        py, 
+                    pyo3_asyncio::PyFuture::try_from(
                         asyncio.call_method1(
                             py, 
                             "sleep", 

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::async_std::main]
@@ -6,7 +8,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::tokio::main]
@@ -6,7 +8,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::tokio::main(flavor = "current_thread")]
@@ -6,7 +8,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::tokio::main(flavor = "multi_thread", worker_threads = 10)]
@@ -6,7 +8,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::PyFuture::try_from(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, thread, time::Duration};
+use std::{convert::TryFrom, future::Future, thread, time::Duration};
 
 use pyo3::prelude::*;
 
@@ -12,7 +12,7 @@ async def sleep_for_1s(sleep_for):
     await sleep_for(1)
 "#;
 
-pub(super) fn test_into_future(
+pub(super) fn test_py_future(
     py: Python,
 ) -> PyResult<impl Future<Output = PyResult<()>> + Send + 'static> {
     let test_mod: PyObject =
@@ -20,8 +20,7 @@ pub(super) fn test_into_future(
 
     Ok(async move {
         Python::with_gil(|py| {
-            pyo3_asyncio::into_future(
-                py,
+            pyo3_asyncio::PyFuture::try_from(
                 test_mod
                     .call_method1(py, "py_sleep", (1.into_py(py),))?
                     .as_ref(py),

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -29,7 +29,7 @@ async fn test_into_coroutine() -> PyResult<()> {
             "test_mod",
         )?;
 
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::PyFuture::try_from(
             test_mod.call_method1("sleep_for_1s", (sleeper_mod.getattr("sleep_for")?,))?,
         )
     })?;
@@ -62,6 +62,11 @@ fn test_blocking_sleep() -> PyResult<()> {
 #[pyo3_asyncio::async_std::test]
 async fn test_py_future() -> PyResult<()> {
     common::test_py_future().await
+}
+
+#[pyo3_asyncio::async_std::test]
+async fn test_into_future() -> PyResult<()> {
+    common::test_into_future().await
 }
 
 #[pyo3_asyncio::async_std::test]

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::{future::Future, time::Duration};
+use std::{convert::TryFrom, future::Future, time::Duration};
 
 use async_std::task;
 use pyo3::{prelude::*, wrap_pyfunction};
@@ -39,8 +39,7 @@ fn test_into_coroutine(
 
     Ok(async move {
         Python::with_gil(|py| {
-            pyo3_asyncio::into_future(
-                py,
+            pyo3_asyncio::PyFuture::try_from(
                 test_mod
                     .call_method1(py, "sleep_for_1s", (sleeper_mod.getattr(py, "sleep_for")?,))?
                     .as_ref(py),
@@ -60,7 +59,7 @@ fn test_async_sleep<'p>(
         task::sleep(Duration::from_secs(1)).await;
 
         Python::with_gil(|py| {
-            pyo3_asyncio::into_future(py, asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
+            pyo3_asyncio::PyFuture::try_from(asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
         })?
         .await?;
 
@@ -99,7 +98,7 @@ fn main() {
             Test::new_async(
                 "test_into_future".into(),
                 Python::with_gil(|py| {
-                    common::test_into_future(py)
+                    common::test_py_future(py)
                         .map_err(|e| {
                             e.print_and_set_sys_last_vars(py);
                         })

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -11,6 +11,7 @@ async fn test_into_coroutine() -> PyResult<()> {
     fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
         let secs = secs.extract()?;
 
+        #[allow(deprecated)]
         pyo3_asyncio::async_std::into_coroutine(py, async move {
             task::sleep(Duration::from_secs(secs)).await;
             Python::with_gil(|py| Ok(py.None()))

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -5,18 +5,18 @@ use std::{convert::TryFrom, time::Duration};
 use async_std::task;
 use pyo3::{prelude::*, wrap_pyfunction};
 
-#[pyfunction]
-fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
-    let secs = secs.extract()?;
-
-    pyo3_asyncio::async_std::into_coroutine(py, async move {
-        task::sleep(Duration::from_secs(secs)).await;
-        Python::with_gil(|py| Ok(py.None()))
-    })
-}
-
 #[pyo3_asyncio::async_std::test]
 async fn test_into_coroutine() -> PyResult<()> {
+    #[pyfunction]
+    fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
+        let secs = secs.extract()?;
+
+        pyo3_asyncio::async_std::into_coroutine(py, async move {
+            task::sleep(Duration::from_secs(secs)).await;
+            Python::with_gil(|py| Ok(py.None()))
+        })
+    }
+
     let fut = Python::with_gil(|py| {
         let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
 
@@ -25,7 +25,41 @@ async fn test_into_coroutine() -> PyResult<()> {
         let test_mod = PyModule::from_code(
             py,
             common::TEST_MOD,
-            "test_rust_coroutine/test_mod.py",
+            "test_into_coroutine/test_mod.py",
+            "test_mod",
+        )?;
+
+        pyo3_asyncio::PyFuture::try_from(
+            test_mod.call_method1("sleep_for_1s", (sleeper_mod.getattr("sleep_for")?,))?,
+        )
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}
+
+#[pyo3_asyncio::async_std::test]
+async fn test_future_into_py() -> PyResult<()> {
+    #[pyfunction]
+    fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+        let secs = secs.extract()?;
+
+        pyo3_asyncio::async_std::future_into_py(py, async move {
+            task::sleep(Duration::from_secs(secs)).await;
+            Python::with_gil(|py| Ok(py.None()))
+        })
+    }
+
+    let fut = Python::with_gil(|py| {
+        let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
+
+        sleeper_mod.add_wrapped(wrap_pyfunction!(sleep_for))?;
+
+        let test_mod = PyModule::from_code(
+            py,
+            common::TEST_MOD,
+            "test_future_into_py/test_mod.py",
             "test_mod",
         )?;
 

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -62,6 +62,11 @@ async fn test_py_future() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::tokio::test]
+async fn test_into_future() -> PyResult<()> {
+    common::test_into_future().await
+}
+
+#[pyo3_asyncio::tokio::test]
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables().await
 }

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, time::Duration};
+use std::{convert::TryFrom, future::Future, time::Duration};
 
 use pyo3::{prelude::*, wrap_pyfunction};
 
@@ -36,8 +36,7 @@ fn test_into_coroutine(
 
     Ok(async move {
         Python::with_gil(|py| {
-            pyo3_asyncio::into_future(
-                py,
+            pyo3_asyncio::PyFuture::try_from(
                 test_mod
                     .call_method1(py, "sleep_for_1s", (sleeper_mod.getattr(py, "sleep_for")?,))?
                     .as_ref(py),
@@ -57,7 +56,7 @@ fn test_async_sleep<'p>(
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         Python::with_gil(|py| {
-            pyo3_asyncio::into_future(py, asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
+            pyo3_asyncio::PyFuture::try_from(asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
         })?
         .await?;
 
@@ -94,9 +93,9 @@ pub(super) fn test_main(suite_name: &str) {
                 }),
             ),
             Test::new_async(
-                "test_into_future".into(),
+                "test_py_future".into(),
                 Python::with_gil(|py| {
-                    common::test_into_future(py)
+                    common::test_py_future(py)
                         .map_err(|e| {
                             e.print_and_set_sys_last_vars(py);
                         })

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -10,6 +10,7 @@ async fn test_into_coroutine() -> PyResult<()> {
     fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
         let secs = secs.extract()?;
 
+        #[allow(deprecated)]
         pyo3_asyncio::tokio::into_coroutine(py, async move {
             tokio::time::sleep(Duration::from_secs(secs)).await;
             Python::with_gil(|py| Ok(py.None()))

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -117,3 +117,34 @@ where
 {
     generic::into_coroutine::<AsyncStdRuntime, _>(py, fut)
 }
+
+/// Convert a Rust Future into a Python Future
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///
+///     pyo3_asyncio::async_std::future_into_py(py, async move {
+///         async_std::task::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///     })
+/// }
+/// ```
+pub fn future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    generic::future_into_py::<AsyncStdRuntime, _>(py, fut)
+}

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -111,10 +111,15 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.13.3",
+    note = "Use pyo3_asyncio::async_std::future_into_py instead"
+)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
+    #[allow(deprecated)]
     generic::into_coroutine::<AsyncStdRuntime, _>(py, fut)
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -95,7 +95,7 @@ where
     R: Runtime,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let coro = into_coroutine::<R, _>(py, async move {
+    let coro = future_into_py::<R, _>(py, async move {
         fut.await?;
         Ok(Python::with_gil(|py| py.None()))
     })?;
@@ -192,6 +192,10 @@ fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResul
 ///    })
 /// }
 /// ```
+#[deprecated(
+    since = "0.13.3",
+    note = "Use pyo3_asyncio::generic::future_into_py instead"
+)]
 pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     R: Runtime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,9 +306,9 @@ impl PyTaskCompleter {
 
 /// Future for a Python `Awaitable`
 ///
-/// This function converts an `Awaitable` into a Python Task using `run_coroutine_threadsafe`. A
+/// This struct converts an `Awaitable` into a Python Task using `run_coroutine_threadsafe`. A
 /// completion handler sends the result of this Task through a
-/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
+/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future
 /// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,49 @@ impl PyEnsureFuture {
     }
 }
 
+/// Convert a Python `awaitable` into a Rust Future
+///
+/// This function converts the `awaitable` into a Python Task using `run_coroutine_threadsafe`. A
+/// completion handler sends the result of this Task through a
+/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
+/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
+///
+/// # Arguments
+/// * `awaitable` - The Python `awaitable` to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::{convert::TryFrom, time::Duration};
+///
+/// use pyo3::prelude::*;
+///
+/// const PYTHON_CODE: &'static str = r#"
+/// import asyncio
+///
+/// async def py_sleep(duration):
+///     await asyncio.sleep(duration)
+/// "#;
+///
+/// async fn py_sleep(seconds: f32) -> PyResult<()> {
+///     Python::with_gil(|py| -> PyResult<_> {
+///         let test_mod = PyModule::from_code(
+///             py,
+///             PYTHON_CODE,
+///             "test_py_future/test_mod.py",
+///             "test_mod"
+///         )?;
+///         
+///         pyo3_asyncio::PyFuture::try_from(
+///             test_mod
+///                 .call_method1("py_sleep", (seconds.into_py(py),))?
+///         )
+///     })?
+///     .await?;
+///
+///     Ok(())    
+/// }
+/// ```
 pub struct PyFuture {
     rx: oneshot::Receiver<PyResult<PyObject>>,
 }
@@ -422,26 +465,21 @@ impl<'p> TryFrom<&'p PyAny> for PyFuture {
 /// "#;
 ///
 /// async fn py_sleep(seconds: f32) -> PyResult<()> {
-///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
-///         Ok(
-///             PyModule::from_code(
-///                 py,
-///                 PYTHON_CODE,
-///                 "test_into_future/test_mod.py",
-///                 "test_mod"
-///             )?
-///             .into()
-///         )
-///     })?;
-///
-///     Python::with_gil(|py| {
+///     Python::with_gil(|py| -> PyResult<_> {
+///         let test_mod = PyModule::from_code(
+///             py,
+///             PYTHON_CODE,
+///             "test_into_future/test_mod.py",
+///             "test_mod"
+///         )?;
+///         
 ///         pyo3_asyncio::into_future(
 ///             test_mod
-///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
-///                 .as_ref(py),
+///                 .call_method1("py_sleep", (seconds.into_py(py),))?
 ///         )
 ///     })?
 ///     .await?;
+///
 ///     Ok(())    
 /// }
 /// ```

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -155,7 +155,7 @@
 //! # ))]
 //! mod tests {
 //!     use pyo3::prelude::*;
-//!     
+//!
 //! #   #[cfg(feature = "async-std-runtime")]
 //!     #[pyo3_asyncio::async_std::test]
 //!     async fn test_async_std_async_test_compiles() -> PyResult<()> {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -207,3 +207,34 @@ where
 {
     generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
+
+/// Convert a Rust Future into a Python Future
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///
+///     pyo3_asyncio::tokio::future_into_py(py, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///     })
+/// }
+/// ```
+pub fn future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    generic::future_into_py::<TokioRuntime, _>(py, fut)
+}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -201,10 +201,15 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.13.3",
+    note = "Use pyo3_asyncio::tokio::future_into_py instead"
+)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
+    #[allow(deprecated)]
     generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
 


### PR DESCRIPTION
Removed `into_future` in favor of a `PyFuture` struct as described in #4 