### PR TITLE
Init changes for #13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,6 @@ features = ["unstable"]
 optional = true
 
 [dependencies.tokio]
-version = "1.0" 
+version = "1.4" 
 features = ["full"]
 optional = true

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -51,3 +51,11 @@ pub(super) async fn test_other_awaitables() -> PyResult<()> {
 
     Ok(())
 }
+
+pub(super) fn test_init_twice() -> PyResult<()> {
+    // try_init has already been called in test main - ensure a second call doesn't mess the other
+    // tests up
+    Python::with_gil(|py| pyo3_asyncio::try_init(py))?;
+
+    Ok(())
+}

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -69,6 +69,11 @@ async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables().await
 }
 
+#[pyo3_asyncio::async_std::test]
+fn test_init_twice() -> PyResult<()> {
+    common::test_init_twice()
+}
+
 #[pyo3_asyncio::async_std::main]
 async fn main() -> pyo3::PyResult<()> {
     pyo3_asyncio::testing::main().await

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -67,3 +67,18 @@ async fn test_into_future() -> PyResult<()> {
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables().await
 }
+
+#[pyo3_asyncio::tokio::test]
+fn test_init_twice() -> PyResult<()> {
+    common::test_init_twice()
+}
+
+#[pyo3_asyncio::tokio::test]
+fn test_init_tokio_twice() -> PyResult<()> {
+    // tokio has already been initialized in test main. call these functions to
+    // make sure they don't cause problems with the other tests.
+    pyo3_asyncio::tokio::init_multi_thread_once();
+    pyo3_asyncio::tokio::init_current_thread_once();
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,9 +193,9 @@ where
 
 /// Attempt to initialize the Python and Rust event loops
 ///
-/// - Must be called before any other pyo3-asyncio functions
-/// - Calling `try_init` twice returns `Ok(())` and does nothing
-///   > In future versions this may return an `Err`
+/// - Must be called before any other pyo3-asyncio functions.
+/// - Calling `try_init` a second time returns `Ok(())` and does nothing.
+///   > In future versions this may return an `Err`.
 pub fn try_init(py: Python) -> PyResult<()> {
     EVENT_LOOP.get_or_try_init(|| -> PyResult<PyObject> {
         let asyncio = py.import("asyncio")?;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -77,6 +77,10 @@ fn start_current_thread() {
 }
 
 /// Initialize the Tokio Runtime with current-thread scheduler
+///
+/// # Panics
+/// This function will panic if called a second time. See [`init_current_thread_once`] if you want
+/// to avoid this panic.
 pub fn init_current_thread() {
     init(current_thread());
     start_current_thread();
@@ -95,6 +99,10 @@ fn multi_thread() -> Runtime {
 }
 
 /// Initialize the Tokio Runtime with the multi-thread scheduler
+///
+/// # Panics
+/// This function will panic if called a second time. See [`init_multi_thread_once`] if you want to
+/// avoid this panic.
 pub fn init_multi_thread() {
     init(multi_thread());
 }
@@ -102,7 +110,7 @@ pub fn init_multi_thread() {
 /// Ensure that the Tokio Runtime is initialized
 ///
 /// If the runtime has not been initialized already, the multi-thread scheduler
-/// is used. Otherwise this function is a no-op.
+/// is used. Calling this function a second time is a no-op.
 pub fn init_multi_thread_once() {
     TOKIO_RUNTIME.get_or_init(|| multi_thread());
 }
@@ -110,7 +118,7 @@ pub fn init_multi_thread_once() {
 /// Ensure that the Tokio Runtime is initialized
 ///
 /// If the runtime has not been initialized already, the current-thread
-/// scheduler is used. Otherwise this function is a no-op
+/// scheduler is used. Calling this function a second time is a no-op.
 pub fn init_current_thread_once() {
     let mut initialized = false;
     TOKIO_RUNTIME.get_or_init(|| {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -63,18 +63,23 @@ pub fn init(runtime: Runtime) {
         .expect("Tokio Runtime has already been initialized");
 }
 
+fn current_thread() -> Runtime {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Couldn't build the current-thread Tokio runtime")
+}
+
+fn start_current_thread() {
+    thread::spawn(move || {
+        TOKIO_RUNTIME.get().unwrap().block_on(pending::<()>());
+    });
+}
+
 /// Initialize the Tokio Runtime with current-thread scheduler
 pub fn init_current_thread() {
-    init(
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Couldn't build the current-thread Tokio runtime"),
-    );
-
-    thread::spawn(|| {
-        get_runtime().block_on(pending::<()>());
-    });
+    init(current_thread());
+    start_current_thread();
 }
 
 /// Get a reference to the current tokio runtime
@@ -82,14 +87,40 @@ pub fn get_runtime<'a>() -> &'a Runtime {
     TOKIO_RUNTIME.get().expect(EXPECT_TOKIO_INIT)
 }
 
+fn multi_thread() -> Runtime {
+    Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Couldn't build the multi-thread Tokio runtime")
+}
+
 /// Initialize the Tokio Runtime with the multi-thread scheduler
 pub fn init_multi_thread() {
-    init(
-        Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("Couldn't build the multi-thread Tokio runtime"),
-    );
+    init(multi_thread());
+}
+
+/// Ensure that the Tokio Runtime is initialized
+///
+/// If the runtime has not been initialized already, the multi-thread scheduler
+/// is used. Otherwise this function is a no-op.
+pub fn init_multi_thread_once() {
+    TOKIO_RUNTIME.get_or_init(|| multi_thread());
+}
+
+/// Ensure that the Tokio Runtime is initialized
+///
+/// If the runtime has not been initialized already, the current-thread
+/// scheduler is used. Otherwise this function is a no-op
+pub fn init_current_thread_once() {
+    let mut initialized = false;
+    TOKIO_RUNTIME.get_or_init(|| {
+        initialized = true;
+        current_thread()
+    });
+
+    if initialized {
+        start_current_thread();
+    }
 }
 
 /// Run the event loop until the given Future completes


### PR DESCRIPTION
# Changes
- Changed `try_init` and `try_close` to public.
- Changed `try_init` to be a no-op if called a second time.
- Added new `init_*_once` fns to `tokio` mod to support calling the `tokio` init fns a second time.
  > Changing the existing `tokio` init fns to support this would be a behavioural change, which means that it shouldn't be done in a patch release. The reason `pyo3_asyncio::try_init` could be changed is because it wasn't already public.
- Added some simple sanity check tests

# Alternatives to Consider
`env_logger::try_init` returns an `Err` if called a second time, which is probably more valid than the current solution. It might be worth returning an `Err`, especially for the `tokio` init fns to signal to the user that the runtime was already initialized (and not necessarily with the same configuration).

It might be worth cleaning this up in a future release, but I figured this PR would serve as a simple patch to fix #13 in the meantime.