### PR TITLE
Async-Std Panic Parity

### DIFF
--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -74,6 +74,29 @@ fn test_init_twice() -> PyResult<()> {
     common::test_init_twice()
 }
 
+#[pyo3_asyncio::async_std::test]
+async fn test_panic() -> PyResult<()> {
+    let fut = Python::with_gil(|py| -> PyResult<_> {
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::async_std::into_coroutine(py, async {
+                panic!("this panic was intentional!")
+            })?
+            .as_ref(py),
+        )
+    })?;
+
+    match fut.await {
+        Ok(_) => panic!("coroutine should panic"),
+        Err(e) => Python::with_gil(|py| {
+            if e.is_instance::<pyo3_asyncio::generic::RustPanic>(py) {
+                Ok(())
+            } else {
+                panic!("expected RustPanic err")
+            }
+        }),
+    }
+}
+
 #[pyo3_asyncio::async_std::main]
 async fn main() -> pyo3::PyResult<()> {
     pyo3_asyncio::testing::main().await

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -88,7 +88,7 @@ async fn test_panic() -> PyResult<()> {
     match fut.await {
         Ok(_) => panic!("coroutine should panic"),
         Err(e) => Python::with_gil(|py| {
-            if e.is_instance::<pyo3_asyncio::generic::RustPanic>(py) {
+            if e.is_instance::<pyo3_asyncio::err::RustPanic>(py) {
                 Ok(())
             } else {
                 panic!("expected RustPanic err")

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use futures::prelude::*;
 use pyo3::{prelude::*, wrap_pyfunction};
 
 use crate::common;
@@ -98,7 +97,7 @@ async fn test_panic() -> PyResult<()> {
     match fut.await {
         Ok(_) => panic!("coroutine should panic"),
         Err(e) => Python::with_gil(|py| {
-            if e.is_instance::<pyo3_asyncio::generic::RustPanic>(py) {
+            if e.is_instance::<pyo3_asyncio::err::RustPanic>(py) {
                 Ok(())
             } else {
                 panic!("expected RustPanic err")

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -24,7 +24,7 @@ pub use pyo3_asyncio_macros::async_std_main as main;
 #[cfg(all(feature = "attributes", feature = "testing"))]
 pub use pyo3_asyncio_macros::async_std_test as test;
 
-pub struct AsyncStdJoinErr(Box<dyn Any + Send + 'static>);
+struct AsyncStdJoinErr(Box<dyn Any + Send + 'static>);
 
 impl JoinError for AsyncStdJoinErr {
     fn is_panic(&self) -> bool {
@@ -32,7 +32,7 @@ impl JoinError for AsyncStdJoinErr {
     }
 }
 
-pub struct AsyncStdRuntime;
+struct AsyncStdRuntime;
 
 impl Runtime for AsyncStdRuntime {
     type JoinError = AsyncStdJoinErr;

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,9 @@
+// FIXME - is there a way to document custom PyO3 exceptions?
+#[allow(missing_docs)]
+mod exceptions {
+    use pyo3::{create_exception, exceptions::PyException};
+
+    create_exception!(pyo3_asyncio, RustPanic, PyException);
+}
+
+pub use exceptions::RustPanic;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
 
-use pyo3::{create_exception, exceptions::PyException, prelude::*};
+use pyo3::prelude::*;
 
-use crate::{dump_err, get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+use crate::{dump_err, err::RustPanic, get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
 
 /// Generic utilities for a JoinError
 pub trait JoinError {
@@ -125,8 +125,6 @@ fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResul
 
     Ok(())
 }
-
-create_exception!(pyo3_asyncio, RustPanic, PyException);
 
 /// Convert a Rust Future into a Python coroutine with a generic runtime
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub mod async_std;
 #[doc(inline)]
 pub mod tokio;
 
+/// Errors and exceptions related to PyO3 Asyncio
+pub mod err;
+
 /// Generic implementations of PyO3 Asyncio utilities that can be used for any Rust runtime
 pub mod generic;
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -40,7 +40,7 @@ impl generic::JoinError for task::JoinError {
     }
 }
 
-struct TokioRuntime;
+pub struct TokioRuntime;
 
 impl generic::Runtime for TokioRuntime {
     type JoinError = task::JoinError;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -40,7 +40,7 @@ impl generic::JoinError for task::JoinError {
     }
 }
 
-pub struct TokioRuntime;
+struct TokioRuntime;
 
 impl generic::Runtime for TokioRuntime {
     type JoinError = task::JoinError;


### PR DESCRIPTION
There was a `todo!()` in the `is_panic` fn for `AsyncStdJoinErr` for a long time, and I just recently figured out how to implement it. This PR makes the `async-std` panic behaviour the same as `tokio`, and adds tests for both `async-std` and tokio for detecting and responding to panics.

One notable exception to the behaviour is that `tokio` worker threads will print a backtrace, which might potentially be desirable. If there's a simple way to add this to the `async-std` impl, I'm open to it.

Something that I would like to add, but am not sure how, is to allow the panic to be resumed via the new `RustPanic` exception. I just need to store the `Box<Any + Send + 'static>` returned by both runtimes so that it can be plugged into the `std::panic::resume_unwind` fn if the user wants to.
