### PR TITLE
Initialization fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio"
 description = "PyO3 utilities for Python's Asyncio library"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]
@@ -90,7 +90,7 @@ inventory = "0.1"
 lazy_static = "1.4"
 once_cell = "1.5"
 pyo3 = "0.13"
-pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.13.3", optional = true }
+pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.13.4", optional = true }
 
 [dependencies.async-std]
 version = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ once_cell = "1.5"
 pyo3 = "0.14"
 pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.14.0", optional = true }
 
+[dev-dependencies]
+pyo3 = { version = "0.14", features = ["macros"] }
+
 [dependencies.async-std]
 version = "1.9"
 features = ["unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio"
 description = "PyO3 utilities for Python's Asyncio library"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]
@@ -89,8 +89,8 @@ futures = "0.3"
 inventory = "0.1"
 lazy_static = "1.4"
 once_cell = "1.5"
-pyo3 = "0.13"
-pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.13.4", optional = true }
+pyo3 = "0.14"
+pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.14.0", optional = true }
 
 [dependencies.async-std]
 version = "1.9"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.13" }
-pyo3-asyncio = { version = "0.13", features = ["attributes", "async-std-runtime"] }
+pyo3 = { version = "0.14" }
+pyo3-asyncio = { version = "0.14", features = ["attributes", "async-std-runtime"] }
 async-std = "1.9"
 ```
 
@@ -60,8 +60,8 @@ attribute.
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.13" }
-pyo3-asyncio = { version = "0.13", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.14" }
+pyo3-asyncio = { version = "0.14", features = ["attributes", "tokio-runtime"] }
 tokio = "1.4"
 ```
 
@@ -84,7 +84,7 @@ async fn main() -> PyResult<()> {
 }
 ```
 
-More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
+More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc) and the primer below.
 
 ### PyO3 Native Rust Modules
 
@@ -104,7 +104,7 @@ For `async-std`:
 ```toml
 [dependencies]
 pyo3 = { version = "0.13", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.13", features = ["async-std-runtime"] }
+pyo3-asyncio = { version = "0.14", features = ["async-std-runtime"] }
 async-std = "1.9"
 ```
 
@@ -112,7 +112,7 @@ For `tokio`:
 ```toml
 [dependencies]
 pyo3 = { version = "0.13", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.13", features = ["tokio-runtime"] }
+pyo3-asyncio = { version = "0.14", features = ["tokio-runtime"] }
 tokio = "1.4"
 ```
 
@@ -158,7 +158,6 @@ fn rust_sleep(py: Python) -> PyResult<&PyAny> {
 #[pymodule]
 fn my_async_module(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
-
     Ok(())
 }
 
@@ -361,6 +360,195 @@ async fn main() -> PyResult<()> {
     Ok(())
 }
 ```
+
+### Event Loop References and Thread-awareness
+
+One problem that arises when interacting with Python's asyncio library is that the functions we use to get a reference to the Python event loop can only be called in certain contexts. Since PyO3 Asyncio requires references to the event loop when performing conversions between Rust and Python, this is unfortunately something that you need to worry about.
+
+#### The Main Dilemma
+
+Python programs can have many independent event loop instances throughout the lifetime of the application (`asyncio.run` for example creates its own event loop each time it's called for instance), and they can even run concurrent with other event loops. The most correct method of obtaining a reference to the Python event loop is via `asyncio.get_running_loop`.
+
+`asyncio.get_running_loop` returns the event loop associated with the current OS thread. It can be used inside Python coroutines to spawn concurrent tasks, interact with timers, or in our case signal between Rust and Python. This is all well and good when we are operating on a Python thread, but what happens when we want to perform a PyO3 Asyncio conversion on a _Rust_ thread? Since the Rust thread is not associated with a Python event loop, `asyncio.get_running_loop` will fail.
+
+#### The Solution
+
+A really straightforward way of dealing with this problem is to pass a reference to the associated Python event loop for every conversion. That's why in PyO3 Asyncio, we introduced a new set of conversion functions that do just that:
+
+- `pyo3_asyncio::into_future_with_loop` - Convert a Python awaitable into a Rust future with the given asyncio event loop.
+- `pyo3_asyncio::<runtime>::future_into_py_with_loop` - Convert a Rust future into a Python awaitable with the given asyncio event loop.
+- `pyo3_asyncio::<runtime>::local_future_into_py_with_loop` - Convert a `!Send` Rust future into a Python awaitable with the given asyncio event loop.
+
+One clear disadvantage to this approach (besides the verbose naming) is that the Rust application has to explicitly track its references to the Python event loop. In native libraries, we can't make any assumptions about the underlying event loop, so the only reliable way to make sure our conversions work properly is to store a reference to the current event loop to use later on.
+
+```rust
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn sleep(py: Python) -> PyResult<&PyAny> {
+    let current_loop = pyo3_asyncio::get_running_loop(py)?;
+    let loop_ref = PyObject::from(current_loop);
+
+    // Convert the async move { } block to a Python awaitable
+    pyo3_asyncio::tokio::future_into_py_with_loop(current_loop, async move {
+        let py_sleep = Python::with_gil(|py| {
+            // Sometimes we need to call other async Python functions within
+            // this future. In order for this to work, we need to track the 
+            // event loop from earlier.
+            pyo3_asyncio::into_future_with_loop(
+                loop_ref.as_ref(py), 
+                py.import("asyncio")?.call_method1("sleep", (1,))?
+            )
+        })?;
+
+        py_sleep.await?;
+
+        Ok(Python::with_gil(|py| py.None()))
+    })
+}
+
+#[pymodule]
+fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sleep, m)?)?;
+    Ok(())
+}
+```
+
+> A naive solution to this tracking problem would be to cache a global reference to the asyncio event loop that all PyO3 Asyncio conversions can use. In fact this is what we did in PyO3 Asyncio `v0.13`. This works well for applications, but it soon became clear that this is not so ideal for libraries. Libraries usually have no direct control over how the event loop is managed, they're just expected to work with any event loop at any point in the application. This problem is compounded further when multiple event loops are used in the application since the global reference will only point to one.
+
+Another disadvantage to this explicit approach that is less obvious is that we can no longer call our `#[pyfunction] fn sleep` on a Rust runtime since `asyncio.get_running_loop` only works on Python threads! It's clear that we need a slightly more flexible approach.
+
+In order to detect the Python event loop at the callsite, we need something like `asyncio.get_running_loop` that works for _both Python and Rust_. In Python, `asyncio.get_running_loop` uses thread-local data to retrieve the event loop associated with the current thread. What we need in Rust is something that can retrieve the Python event loop associated with the current _task_.
+
+Enter `pyo3_asyncio::<runtime>::get_current_loop`. This function first checks task-local data for a Python event loop, then falls back on `asyncio.get_running_loop` if no task-local event loop is found. This way both bases are convered.
+
+Now, all we need is a way to store the event loop in task-local data. Since this is a runtime-specific feature, you can find the following functions in each runtime module:
+
+- `pyo3_asyncio::<runtime>::scope` - Store the event loop in task-local data when executing the given Future.
+- `pyo3_asyncio::<runtime>::scope_local` - Store the event loop in task-local data when executing the given `!Send` Future.
+
+With these new functions, we can make our previous example more correct:
+
+```rust no_run
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn sleep(py: Python) -> PyResult<&PyAny> {
+    // get the current event loop through task-local data 
+    // OR `asyncio.get_running_loop`
+    let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
+
+    pyo3_asyncio::tokio::future_into_py_with_loop(
+        current_loop, 
+        pyo3_asyncio::tokio::scope(current_loop.into(), async move {
+            let py_sleep = Python::with_gil(|py| {
+                pyo3_asyncio::into_future_with_loop(
+                    // Now we can get the current loop through task-local data
+                    pyo3_asyncio::tokio::get_current_loop(py)?, 
+                    py.import("asyncio")?.call_method1("sleep", (1,))?
+                )
+            })?;
+
+            py_sleep.await?;
+
+            Ok(Python::with_gil(|py| py.None()))
+        })
+    )
+}
+
+#[pyfunction]
+fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
+    // get the current event loop through task-local data 
+    // OR `asyncio.get_running_loop`
+    let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
+
+    pyo3_asyncio::tokio::future_into_py_with_loop(
+        current_loop, 
+        pyo3_asyncio::tokio::scope(current_loop.into(), async move {
+            let py_sleep = Python::with_gil(|py| {
+                pyo3_asyncio::into_future_with_loop(
+                    pyo3_asyncio::tokio::get_current_loop(py)?, 
+                    // We can also call sleep within a Rust task since the
+                    // event loop is stored in task local data
+                    sleep(py)?
+                )
+            })?;
+
+            py_sleep.await?;
+
+            Ok(Python::with_gil(|py| py.None()))
+        })
+    )
+}
+
+#[pymodule]
+fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sleep, m)?)?;
+    m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
+    Ok(())
+}
+```
+
+Even though this is more correct, it's clearly not more ergonomic. That's why we introduced a new set of functions with this functionality baked in:
+
+- `pyo3_asyncio::<runtime>::into_future` - Convert a Python awaitable into a Rust future (using `pyo3_asyncio::<runtime>::get_current_loop`)
+- `pyo3_asyncio::<runtime>::future_into_py` - Convert a Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope` to set the task-local event loop for the given Rust future)
+- `pyo3_asyncio::<runtime>::local_future_into_py` - Convert a `!Send` Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope_local` to set the task-local event loop for the given Rust future).
+
+__These are the functions that we recommend using__. With these functions, the previous example can be written like so:
+
+```rust
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn sleep(py: Python) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async move {
+        let py_sleep = Python::with_gil(|py| {
+            pyo3_asyncio::tokio::into_future(
+                py.import("asyncio")?.call_method1("sleep", (1,))?
+            )
+        })?;
+
+        py_sleep.await?;
+
+        Ok(Python::with_gil(|py| py.None()))
+    })
+}
+
+#[pyfunction]
+fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async move {
+        let py_sleep = Python::with_gil(|py| {
+            pyo3_asyncio::tokio::into_future(sleep(py)?)
+        })?;
+
+        py_sleep.await?;
+
+        Ok(Python::with_gil(|py| py.None()))
+    })
+}
+
+#[pymodule]
+fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sleep, m)?)?;
+    m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
+    Ok(())
+}
+```
+
+### A Note for `v0.13` Users
+
+Hey guys, I realize that these are pretty major changes for `v0.14`, and I apologize in advance for having to modify the public API so much. I hope
+the explanation above gives some much needed context and justification for all the breaking changes.
+
+Part of the reason why it's taken so long to push out a `v0.14` release is because I wanted to make sure we got this release right. There were a lot of issues with the `v0.13` release that I hadn't anticipated, and it's thanks to your feedback and patience that we've worked through these issues to get a more correct, more flexible version out there!
+
+This new release should address most the core issues that users have reported in the `v0.13` release, so I think we can expect more stability going forward.
+
+Also, a special thanks to @ShadowJonathan for helping with the design and review
+of these changes!
+
+- @awestlake87
 
 ## PyO3 Asyncio in Cargo Tests
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ In the following sections, we'll give a general overview of `pyo3-asyncio` expla
 async Python functions with PyO3, how to call async Rust functions from Python, and how to configure
 your codebase to manage the runtimes of both.
 
-## Quickstart
+### Quickstart
 
 Here are some examples to get you started right away! A more detailed breakdown
 of the concepts in these examples can be found in the following sections.
 
-### Rust Applications
+#### Rust Applications
 Here we initialize the runtime, import Python's `asyncio` library and run the given future to completion using Python's default `EventLoop` and `async-std`. Inside the future, we convert `asyncio` sleep into a Rust future and await it.
 
 
@@ -101,7 +101,7 @@ async fn main() -> PyResult<()> {
 
 More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc) and the primer below.
 
-### PyO3 Native Rust Modules
+#### PyO3 Native Rust Modules
 
 PyO3 Asyncio can also be used to write native modules with async functions.
 
@@ -118,7 +118,7 @@ Make your project depend on `pyo3` with the `extension-module` feature enabled a
 For `async-std`:
 ```toml
 [dependencies]
-pyo3 = { version = "0.13", features = ["extension-module"] }
+pyo3 = { version = "0.14", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.14", features = ["async-std-runtime"] }
 async-std = "1.9"
 ```
@@ -126,7 +126,7 @@ async-std = "1.9"
 For `tokio`:
 ```toml
 [dependencies]
-pyo3 = { version = "0.13", features = ["extension-module"] }
+pyo3 = { version = "0.14", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.14", features = ["tokio-runtime"] }
 tokio = "1.4"
 ```
@@ -175,19 +175,15 @@ fn my_async_module(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
     Ok(())
 }
-
 ```
 
-Build your module and rename `libmy_async_module.so` to `my_async_module.so`
-```bash
-cargo build --release && mv target/release/libmy_async_module.so target/release/my_async_module.so
-```
-
-Now, point your `PYTHONPATH` to the directory containing `my_async_module.so`, then you'll be able 
-to import and use it:
+You can build your module with maturin (see the [Using Rust in Python](https://pyo3.rs/main/#using-rust-from-python) section in the PyO3 guide for setup instructions). After that you should be able to run the Python REPL to try it out.
 
 ```bash
-$ PYTHONPATH=target/release python3
+maturin develop && python3
+🔗 Found pyo3 bindings
+🐍 Found CPython 3.8 at python3
+    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
 Python 3.8.5 (default, Jan 27 2021, 15:41:15) 
 [GCC 9.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
@@ -203,7 +199,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
 
-## Awaiting an Async Python Function in Rust
+### Awaiting an Async Python Function in Rust
 
 Let's take a look at a dead simple async Python function:
 
@@ -253,7 +249,7 @@ async fn main() -> PyResult<()> {
 > If you're interested in learning more about `coroutines` and `awaitables` in general, check out the 
 > [Python 3 `asyncio` docs](https://docs.python.org/3/library/asyncio-task.html) for more information.
 
-## Awaiting a Rust Future in Python
+### Awaiting a Rust Future in Python
 
 Here we have the same async function as before written in Rust using the 
 [`async-std`](https://async.rs/) runtime:
@@ -362,7 +358,7 @@ async fn main() -> PyResult<()> {
 }
 ```
 
-### A Note About `asyncio.run`
+#### A Note About `asyncio.run`
 
 In Python 3.7+, the recommended way to run a top-level coroutine with `asyncio`
 is with `asyncio.run`. In `v0.13` we recommended against using this function due to initialization issues, but in `v0.14` it's perfectly valid to use this function... with a caveat.
@@ -381,7 +377,8 @@ asyncio.run(rust_sleep())
 You might be surprised to find out that this throws an error:
 ```bash
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
+  File "example.py", line 5, in <module>
+    asyncio.run(rust_sleep())
 RuntimeError: no running event loop
 ```
 
@@ -405,7 +402,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### Non-standard Python Event Loops
+#### Non-standard Python Event Loops
 
 Python allows you to use alternatives to the default `asyncio` event loop. One
 popular alternative is `uvloop`. In `v0.13` using non-standard event loops was
@@ -421,7 +418,7 @@ name = "my_async_module"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.14", features = ["extension-module", "auto-initialize"] }
+pyo3 = { version = "0.14", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.14", features = ["tokio-runtime"] }
 async-std = "1.9"
 tokio = "1.4"
@@ -449,10 +446,10 @@ fn my_async_module(_py: Python, m: &PyModule) -> PyResult<()> {
 ```
 
 ```bash
-$ cargo build --release && mv target/release/libmy_async_module.so my_async_module.so
-   Compiling pyo3-asyncio-lib v0.1.0 (pyo3-asyncio-lib)
-    Finished release [optimized] target(s) in 1.00s
-$ PYTHONPATH=target/release/ python3
+$ maturin develop && python3
+🔗 Found pyo3 bindings
+🐍 Found CPython 3.8 at python3
+    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
 Python 3.8.8 (default, Apr 13 2021, 19:58:26) 
 [GCC 7.3.0] :: Anaconda, Inc. on linux
 Type "help", "copyright", "credits" or "license" for more information.
@@ -475,7 +472,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 Using `uvloop` in Rust applications is a bit trickier, but it's still possible
 with relatively few modifications.
 
-> Unfortunately, we can't make use of the `#[pyo3_asyncio::<runtime>::main]` attribute with non-standard event loops. This is because the `#[pyo3_asyncio::<runtime>::main]` proc macro has to interact with the Python
+Unfortunately, we can't make use of the `#[pyo3_asyncio::<runtime>::main]` attribute with non-standard event loops. This is because the `#[pyo3_asyncio::<runtime>::main]` proc macro has to interact with the Python
 event loop before we can install the `uvloop` policy.
 
 ```toml
@@ -520,316 +517,9 @@ fn main() -> PyResult<()> {
 }
 ```
 
-### Event Loop References and Thread-awareness
-
-One problem that arises when interacting with Python's asyncio library is that the functions we use to get a reference to the Python event loop can only be called in certain contexts. Since PyO3 Asyncio needs to interact with Python's event loop during conversions, the context of these conversions can matter a lot. 
-
-> The core conversions we've mentioned so far in this guide should insulate you from these concerns in most cases, but in the event that they don't, this section should provide you with the information you need to solve these problems.
-
-#### The Main Dilemma
-
-Python programs can have many independent event loop instances throughout the lifetime of the application (`asyncio.run` for example creates its own event loop each time it's called for instance), and they can even run concurrent with other event loops. For this reason, the most correct method of obtaining a reference to the Python event loop is via `asyncio.get_running_loop`.
-
-`asyncio.get_running_loop` returns the event loop associated with the current OS thread. It can be used inside Python coroutines to spawn concurrent tasks, interact with timers, or in our case signal between Rust and Python. This is all well and good when we are operating on a Python thread, but since Rust threads are not associated with a Python event loop, `asyncio.get_running_loop` will fail when called on a Rust runtime.
-
-#### The Solution
-
-A really straightforward way of dealing with this problem is to pass a reference to the associated Python event loop for every conversion. That's why in `v0.14`, we introduced a new set of conversion functions that do just that:
-
-- `pyo3_asyncio::into_future_with_loop` - Convert a Python awaitable into a Rust future with the given asyncio event loop.
-- `pyo3_asyncio::<runtime>::future_into_py_with_loop` - Convert a Rust future into a Python awaitable with the given asyncio event loop.
-- `pyo3_asyncio::<runtime>::local_future_into_py_with_loop` - Convert a `!Send` Rust future into a Python awaitable with the given asyncio event loop.
-
-One clear disadvantage to this approach (aside from the verbose naming) is that the Rust application has to explicitly track its references to the Python event loop. In native libraries, we can't make any assumptions about the underlying event loop, so the only reliable way to make sure our conversions work properly is to store a reference to the current event loop at the callsite to use later on.
-
-```rust
-use pyo3::prelude::*;
-
-#[pyfunction]
-fn sleep(py: Python) -> PyResult<&PyAny> {
-    let current_loop = pyo3_asyncio::get_running_loop(py)?;
-    let loop_ref = PyObject::from(current_loop);
-
-    // Convert the async move { } block to a Python awaitable
-    pyo3_asyncio::tokio::future_into_py_with_loop(current_loop, async move {
-        let py_sleep = Python::with_gil(|py| {
-            // Sometimes we need to call other async Python functions within
-            // this future. In order for this to work, we need to track the 
-            // event loop from earlier.
-            pyo3_asyncio::into_future_with_loop(
-                loop_ref.as_ref(py), 
-                py.import("asyncio")?.call_method1("sleep", (1,))?
-            )
-        })?;
-
-        py_sleep.await?;
-
-        Ok(Python::with_gil(|py| py.None()))
-    })
-}
-
-#[pymodule]
-fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sleep, m)?)?;
-    Ok(())
-}
-```
-
-> A naive solution to this tracking problem would be to cache a global reference to the asyncio event loop that all PyO3 Asyncio conversions can use. In fact this is what we did in PyO3 Asyncio `v0.13`. This works well for applications, but it soon became clear that this is not so ideal for libraries. Libraries usually have no direct control over how the event loop is managed, they're just expected to work with any event loop at any point in the application. This problem is compounded further when multiple event loops are used in the application since the global reference will only point to one.
-
-Another disadvantage to this explicit approach that is less obvious is that we can no longer call our `#[pyfunction] fn sleep` on a Rust runtime since `asyncio.get_running_loop` only works on Python threads! It's clear that we need a slightly more flexible approach.
-
-In order to detect the Python event loop at the callsite, we need something like `asyncio.get_running_loop` that works for _both Python and Rust_. In Python, `asyncio.get_running_loop` uses thread-local data to retrieve the event loop associated with the current thread. What we need in Rust is something that can retrieve the Python event loop associated with the current _task_.
-
-Enter `pyo3_asyncio::<runtime>::get_current_loop`. This function first checks task-local data for a Python event loop, then falls back on `asyncio.get_running_loop` if no task-local event loop is found. This way both bases are covered.
-
-Now, all we need is a way to store the event loop in task-local data. Since this is a runtime-specific feature, you can find the following functions in each runtime module:
-
-- `pyo3_asyncio::<runtime>::scope` - Store the event loop in task-local data when executing the given Future.
-- `pyo3_asyncio::<runtime>::scope_local` - Store the event loop in task-local data when executing the given `!Send` Future.
-
-With these new functions, we can make our previous example more correct:
-
-```rust no_run
-use pyo3::prelude::*;
-
-#[pyfunction]
-fn sleep(py: Python) -> PyResult<&PyAny> {
-    // get the current event loop through task-local data 
-    // OR `asyncio.get_running_loop`
-    let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
-
-    pyo3_asyncio::tokio::future_into_py_with_loop(
-        current_loop, 
-        // Store the current loop in task-local data 
-        pyo3_asyncio::tokio::scope(current_loop.into(), async move {
-            let py_sleep = Python::with_gil(|py| {
-                pyo3_asyncio::into_future_with_loop(
-                    // Now we can get the current loop through task-local data
-                    pyo3_asyncio::tokio::get_current_loop(py)?, 
-                    py.import("asyncio")?.call_method1("sleep", (1,))?
-                )
-            })?;
-
-            py_sleep.await?;
-
-            Ok(Python::with_gil(|py| py.None()))
-        })
-    )
-}
-
-#[pyfunction]
-fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
-    // get the current event loop through task-local data 
-    // OR `asyncio.get_running_loop`
-    let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
-
-    pyo3_asyncio::tokio::future_into_py_with_loop(
-        current_loop, 
-        // Store the current loop in task-local data 
-        pyo3_asyncio::tokio::scope(current_loop.into(), async move {
-            let py_sleep = Python::with_gil(|py| {
-                pyo3_asyncio::into_future_with_loop(
-                    pyo3_asyncio::tokio::get_current_loop(py)?, 
-                    // We can also call sleep within a Rust task since the
-                    // event loop is stored in task local data
-                    sleep(py)?
-                )
-            })?;
-
-            py_sleep.await?;
-
-            Ok(Python::with_gil(|py| py.None()))
-        })
-    )
-}
-
-#[pymodule]
-fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sleep, m)?)?;
-    m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
-    Ok(())
-}
-```
-
-Even though this is more correct, it's clearly not more ergonomic. That's why we introduced a new set of functions with this functionality baked in:
-
-- `pyo3_asyncio::<runtime>::into_future` 
-  > Convert a Python awaitable into a Rust future (using `pyo3_asyncio::<runtime>::get_current_loop`)
-- `pyo3_asyncio::<runtime>::future_into_py` 
-  > Convert a Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope` to set the task-local event loop for the given Rust future)
-- `pyo3_asyncio::<runtime>::local_future_into_py` 
-  > Convert a `!Send` Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope_local` to set the task-local event loop for the given Rust future).
-
-__These are the functions that we recommend using__. With these functions, the previous example can be rewritten to be more compact:
-
-```rust
-use pyo3::prelude::*;
-
-#[pyfunction]
-fn sleep(py: Python) -> PyResult<&PyAny> {
-    pyo3_asyncio::tokio::future_into_py(py, async move {
-        let py_sleep = Python::with_gil(|py| {
-            pyo3_asyncio::tokio::into_future(
-                py.import("asyncio")?.call_method1("sleep", (1,))?
-            )
-        })?;
-
-        py_sleep.await?;
-
-        Ok(Python::with_gil(|py| py.None()))
-    })
-}
-
-#[pyfunction]
-fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
-    pyo3_asyncio::tokio::future_into_py(py, async move {
-        let py_sleep = Python::with_gil(|py| {
-            pyo3_asyncio::tokio::into_future(sleep(py)?)
-        })?;
-
-        py_sleep.await?;
-
-        Ok(Python::with_gil(|py| py.None()))
-    })
-}
-
-#[pymodule]
-fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sleep, m)?)?;
-    m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
-    Ok(())
-}
-```
-
-### A Note for `v0.13` Users
-
-Hey guys, I realize that these are pretty major changes for `v0.14`, and I apologize in advance for having to modify the public API so much. I hope
-the explanation above gives some much needed context and justification for all the breaking changes.
-
-Part of the reason why it's taken so long to push out a `v0.14` release is because I wanted to make sure we got this release right. There were a lot of issues with the `v0.13` release that I hadn't anticipated, and it's thanks to your feedback and patience that we've worked through these issues to get a more correct, more flexible version out there!
-
-This new release should address most the core issues that users have reported in the `v0.13` release, so I think we can expect more stability going forward.
-
-Also, a special thanks to [@ShadowJonathan](https://github.com/ShadowJonathan) for helping with the design and review
-of these changes!
-
-- [@awestlake87](https://github.com/awestlake87)
-
-## PyO3 Asyncio in Cargo Tests
-
-The default Cargo Test harness does not currently allow test crates to provide their own `main` 
-function, so there doesn't seem to be a good way to allow Python to gain control over the main
-thread.
-
-We can, however, override the default test harness and provide our own. `pyo3-asyncio` provides some
-utilities to help us do just that! In the following sections, we will provide an overview for 
-constructing a Cargo integration test with `pyo3-asyncio` and adding your tests to it.
-
-### Main Test File
-First, we need to create the test's main file. Although these tests are considered integration
-tests, we cannot put them in the `tests` directory since that is a special directory owned by
-Cargo. Instead, we put our tests in a `pytests` directory.
-
-> The name `pytests` is just a convention. You can name this folder anything you want in your own
-> projects.
-
-We'll also want to provide the test's main function. Most of the functionality that the test harness needs is packed in the [`pyo3_asyncio::testing::main`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/testing/fn.main.html) function. This function will parse the test's CLI arguments, collect and pass the functions marked with [`#[pyo3_asyncio::async_std::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) or [`#[pyo3_asyncio::tokio::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) and pass them into the test harness for running and filtering.
-
-`pytests/test_example.rs` for the `tokio` runtime:
-```rust
-#[pyo3_asyncio::tokio::main]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
-}
-```
-
-`pytests/test_example.rs` for the `async-std` runtime:
-```rust
-#[pyo3_asyncio::async_std::main]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
-}
-```
-
-### Cargo Configuration
-Next, we need to add our test file to the Cargo manifest by adding the following section to the
-`Cargo.toml`
-
-```toml
-[[test]]
-name = "test_example"
-path = "pytests/test_example.rs"
-harness = false
-```
-
-Also add the `testing` and `attributes` features to the `pyo3-asyncio` dependency and select your preferred runtime:
-
-```toml
-pyo3-asyncio = { version = "0.13", features = ["testing", "attributes", "async-std-runtime"] }
-```
-
-At this point, you should be able to run the test via `cargo test`
-
-### Adding Tests to the PyO3 Asyncio Test Harness
-
-We can add tests anywhere in the test crate with the runtime's corresponding `#[test]` attribute:
-
-For `async-std` use the [`pyo3_asyncio::async_std::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) attribute:
-```rust
-mod tests {
-    use std::{time::Duration, thread};
-
-    use pyo3::prelude::*;
-
-    // tests can be async
-    #[pyo3_asyncio::async_std::test]
-    async fn test_async_sleep() -> PyResult<()> {
-        async_std::task::sleep(Duration::from_secs(1)).await;
-        Ok(())
-    }
-
-    // they can also be synchronous
-    #[pyo3_asyncio::async_std::test]
-    fn test_blocking_sleep() -> PyResult<()> {
-        thread::sleep(Duration::from_secs(1));
-        Ok(())
-    }
-}
-
-#[pyo3_asyncio::async_std::main]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
-}
-```
-
-For `tokio` use the [`pyo3_asyncio::tokio::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) attribute:
-```rust
-mod tests {
-    use std::{time::Duration, thread};
-
-    use pyo3::prelude::*;
-
-    // tests can be async
-    #[pyo3_asyncio::tokio::test]
-    async fn test_async_sleep() -> PyResult<()> {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        Ok(())
-    }
-
-    // they can also be synchronous
-    #[pyo3_asyncio::tokio::test]
-    fn test_blocking_sleep() -> PyResult<()> {
-        thread::sleep(Duration::from_secs(1));
-        Ok(())
-    }
-}
-
-#[pyo3_asyncio::tokio::main]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
-}
-```
+### Additional Information
+- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://docs.rs/pyo3-asyncio/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
+- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://docs.rs/pyo3-asyncio/testing)
 
 ## Migrating from 0.13 to 0.14
 
@@ -855,6 +545,7 @@ __Before you get started, I personally recommend taking a look at [Event Loop Re
   - `pyo3_asyncio::<runtime>::future_into_py`
   - `pyo3_asyncio::<runtime>::local_future_into_py`
   - `pyo3_asyncio::<runtime>::get_current_loop`
+- `pyo3_asyncio::try_init` is no longer required if you're only using `0.14` conversions
 - The `ThreadPoolExecutor` is no longer configured automatically at the start.
   - Fortunately, this doesn't seem to have much effect on `v0.13` code, it just means that it's now possible to configure the executor manually as you see fit.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
 fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::async_std::into_coroutine(pyo3_asyncio::async_std::current_event_loop(py)?, async {
+    pyo3_asyncio::async_std::into_coroutine(py, async {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })
@@ -149,7 +149,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
 fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::tokio::into_coroutine(pyo3_asyncio::tokio::current_event_loop(py)?, async {
+    pyo3_asyncio::tokio::into_coroutine(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py), 
+            asyncio.call_method1("sleep", (1.into_py(py),))?
+        )
     })?;
 
     fut.await?;
@@ -77,7 +80,10 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py), 
+            asyncio.call_method1("sleep", (1.into_py(py),))?
+        )
     })?;
 
     fut.await?;
@@ -127,7 +133,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
 fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::async_std::into_coroutine(py, async {
+    pyo3_asyncio::async_std::into_coroutine(pyo3_asyncio::get_event_loop(py)?, async {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })
@@ -153,7 +159,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
 fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::tokio::into_coroutine(py, async {
+    pyo3_asyncio::tokio::into_coroutine(pyo3_asyncio::get_event_loop(py)?, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })

--- a/README.md
+++ b/README.md
@@ -924,6 +924,8 @@ __Before you get started, I personally recommend taking a look at [Event Loop Re
     - Replace `pyo3_asyncio::get_event_loop` with `pyo3_asyncio::<runtime>::get_current_loop`
 5. After all conversions have been replaced with their `v0.14` counterparts, `pyo3_asyncio::try_init` can safely be removed.
 
+> The `v0.13` API will likely still be supported in version `v0.15`, but no solid guarantees after that point.
+
 ## Known Problems
 
 This library can give spurious failures during finalization prior to PyO3 release `v0.13.2`. Make sure your PyO3 dependency is up-to-date!

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py), 
             asyncio.call_method1("sleep", (1.into_py(py),))?
         )
@@ -80,7 +80,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py), 
             asyncio.call_method1("sleep", (1.into_py(py),))?
         )

--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ fn main() -> PyResult<()> {
 ```
 
 ### Additional Information
-- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://awestlake87.github.io/pyo3-asyncio/master/doc/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
-- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/testing)
+- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
+- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/testing)
 
 ## Migrating from 0.13 to 0.14
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,20 @@ This library can give spurious failures during finalization prior to PyO3 releas
 ### Rust Applications
 Here we initialize the runtime, import Python's `asyncio` library and run the given future to completion using Python's default `EventLoop` and `async-std`. Inside the future, we convert `asyncio` sleep into a Rust future and await it.
 
-More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
+
+```toml
+# Cargo.toml
+...
+
+[dependencies]
+pyo3 = { version = "0.13" }
+pyo3-asyncio = { version = "0.13", features = ["attributes", "async-std-runtime"] }
+async-std = "1.9"
+```
 
 ```rust
+//! main.rs
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::async_std::main]
@@ -49,7 +60,19 @@ async fn main() -> PyResult<()> {
 The same application can be written to use `tokio` instead using the `#[pyo3_asyncio::tokio::main]`
 attribute.
 
+```toml
+# Cargo.toml
+...
+
+[dependencies]
+pyo3 = { version = "0.13" }
+pyo3-asyncio = { version = "0.13", features = ["attributes", "tokio-runtime"] }
+tokio = "1.4"
+```
+
 ```rust
+//! main.rs
+
 use pyo3::prelude::*;
 
 #[pyo3_asyncio::tokio::main]
@@ -66,6 +89,8 @@ async fn main() -> PyResult<()> {
     Ok(())
 }
 ```
+
+More details on the usage of this library can be found in the [API docs](https://awestlake87.github.io/pyo3-asyncio/master/doc).
 
 ### PyO3 Native Rust Modules
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 
 
 ```toml
-# Cargo.toml
-...
-
+# Cargo.toml dependencies
 [dependencies]
 pyo3 = { version = "0.13" }
 pyo3-asyncio = { version = "0.13", features = ["attributes", "async-std-runtime"] }
@@ -61,9 +59,7 @@ The same application can be written to use `tokio` instead using the `#[pyo3_asy
 attribute.
 
 ```toml
-# Cargo.toml
-...
-
+# Cargo.toml dependencies
 [dependencies]
 pyo3 = { version = "0.13" }
 pyo3-asyncio = { version = "0.13", features = ["attributes", "tokio-runtime"] }

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ asyncio.run(rust_sleep())
 ```
 
 You might be surprised to find out that this throws an error:
-```
+```bash
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 RuntimeError: no running event loop

--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ fn main() -> PyResult<()> {
 ```
 
 ### Additional Information
-- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://docs.rs/pyo3-asyncio/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
-- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://docs.rs/pyo3-asyncio/testing)
+- Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://awestlake87.github.io/pyo3-asyncio/master/doc/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
+- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/testing)
 
 ## Migrating from 0.13 to 0.14
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Export an async function that makes use of `async-std`:
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::async_std::into_coroutine(py, async {
+fn rust_sleep(py: Python) -> PyResult<&PyAny> {
+    pyo3_asyncio::async_std::future_into_py(py, async {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })
@@ -148,8 +148,8 @@ If you want to use `tokio` instead, here's what your module should look like:
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn rust_sleep(py: Python) -> PyResult<PyObject> {
-    pyo3_asyncio::tokio::into_coroutine(py, async {
+fn rust_sleep(py: Python) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(Python::with_gil(|py| py.None()))
     })
@@ -157,10 +157,6 @@ fn rust_sleep(py: Python) -> PyResult<PyObject> {
 
 #[pymodule]
 fn my_async_module(py: Python, m: &PyModule) -> PyResult<()> {
-    // Tokio needs explicit initialization before any pyo3-asyncio conversions.
-    // The module import is a prime place to do this.
-    pyo3_asyncio::tokio::init_multi_thread_once();
-
     m.add_function(wrap_pyfunction!(rust_sleep, m)?)?;
 
     Ok(())

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Actions Status](https://github.com/awestlake87/pyo3-asyncio/workflows/CI/badge.svg)](https://github.com/awestlake87/pyo3-asyncio/actions)
 [![codecov](https://codecov.io/gh/awestlake87/pyo3-asyncio/branch/master/graph/badge.svg)](https://codecov.io/gh/awestlake87/pyo3-asyncio)
-[![crates.io](http://meritbadge.herokuapp.com/pyo3-asyncio)](https://crates.io/crates/pyo3-asyncio)
+[![crates.io](https://img.shields.io/crates/v/pyo3-asyncio)](https://crates.io/crates/pyo3-asyncio)
 [![minimum rustc 1.46](https://img.shields.io/badge/rustc-1.46+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/)'s [Asyncio Library](https://docs.python.org/3/library/asyncio.html). This crate facilitates interactions between Rust Futures and Python Coroutines and manages the lifecycle of their corresponding event loops.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,294 @@ Type "help", "copyright", "credits" or "license" for more information.
 > 
 > This restriction may be lifted in a future release.
 
+## PyO3 Asyncio Primer
+
+If you are working with a Python library that makes use of async functions or wish to provide 
+Python bindings for an async Rust library, [`pyo3-asyncio`](https://github.com/awestlake87/pyo3-asyncio)
+likely has the tools you need. It provides conversions between async functions in both Python and 
+Rust and was designed with first-class support for popular Rust runtimes such as 
+[`tokio`](https://tokio.rs/) and [`async-std`](https://async.rs/). In addition, all async Python 
+code runs on the default `asyncio` event loop, so `pyo3-asyncio` should work just fine with existing 
+Python libraries.
+
+In the following sections, we'll give a general overview of `pyo3-asyncio` explaining how to call 
+async Python functions with PyO3, how to call async Rust functions from Python, and how to configure
+your codebase to manage the runtimes of both.
+
+## Awaiting an Async Python Function in Rust
+
+Let's take a look at a dead simple async Python function:
+
+```python
+# Sleep for 1 second
+async def py_sleep():
+    await asyncio.sleep(1)
+```
+
+**Async functions in Python are simply functions that return a `coroutine` object**. For our purposes, 
+we really don't need to know much about these `coroutine` objects. The key factor here is that calling
+an `async` function is _just like calling a regular function_, the only difference is that we have
+to do something special with the object that it returns.
+
+Normally in Python, that something special is the `await` keyword, but in order to await this 
+coroutine in Rust, we first need to convert it into Rust's version of a `coroutine`: a `Future`. 
+That's where `pyo3-asyncio` comes in. 
+[`pyo3_asyncio::into_future`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/fn.into_future.html) 
+performs this conversion for us:
+
+
+```rust no_run
+use pyo3::prelude::*;
+
+#[pyo3_asyncio::tokio::main]
+async fn main() -> PyResult<()> {
+    let future = Python::with_gil(|py| -> PyResult<_> {
+        // import the module containing the py_sleep function
+        let example = py.import("example")?;
+
+        // calling the py_sleep method like a normal function 
+        // returns a coroutine
+        let coroutine = example.call_method0("py_sleep")?;
+
+        // convert the coroutine into a Rust future using the 
+        // tokio runtime
+        pyo3_asyncio::tokio::into_future(coroutine)
+    })?;
+
+    // await the future
+    future.await?;
+
+    Ok(())
+}
+```
+
+> If you're interested in learning more about `coroutines` and `awaitables` in general, check out the 
+> [Python 3 `asyncio` docs](https://docs.python.org/3/library/asyncio-task.html) for more information.
+
+## Awaiting a Rust Future in Python
+
+Here we have the same async function as before written in Rust using the 
+[`async-std`](https://async.rs/) runtime:
+
+```rust
+/// Sleep for 1 second
+async fn rust_sleep() {
+    async_std::task::sleep(std::time::Duration::from_secs(1)).await;
+}
+```
+
+Similar to Python, Rust's async functions also return a special object called a
+`Future`:
+
+```rust compile_fail
+let future = rust_sleep();
+```
+
+We can convert this `Future` object into Python to make it `awaitable`. This tells Python that you 
+can use the `await` keyword with it. In order to do this, we'll call 
+[`pyo3_asyncio::async_std::future_into_py`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/fn.future_into_py.html):
+
+```rust
+use pyo3::prelude::*;
+
+async fn rust_sleep() {
+    async_std::task::sleep(std::time::Duration::from_secs(1)).await;
+}
+
+#[pyfunction]
+fn call_rust_sleep(py: Python) -> PyResult<&PyAny> {
+    pyo3_asyncio::async_std::future_into_py(py, async move {
+        rust_sleep().await;
+        Ok(Python::with_gil(|py| py.None()))
+    })
+}
+```
+
+In Python, we can call this pyo3 function just like any other async function:
+
+```python
+from example import call_rust_sleep
+
+async def rust_sleep():
+    await call_rust_sleep()
+```
+
+## Managing Event Loops
+
+Python's event loop requires some special treatment, especially regarding the main thread. Some of
+Python's `asyncio` features, like proper signal handling, require control over the main thread, which
+doesn't always play well with Rust.
+
+Luckily, Rust's event loops are pretty flexible and don't _need_ control over the main thread, so in
+`pyo3-asyncio`, we decided the best way to handle Rust/Python interop was to just surrender the main
+thread to Python and run Rust's event loops in the background. Unfortunately, since most event loop 
+implementations _prefer_ control over the main thread, this can still make some things awkward.
+
+### PyO3 Asyncio Initialization
+
+Because Python needs to control the main thread, we can't use the convenient proc macros from Rust
+runtimes to handle the `main` function or `#[test]` functions. Instead, the initialization for PyO3 has to be done from the `main` function and the main 
+thread must block on [`pyo3_asyncio::run_forever`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/fn.run_forever.html) or [`pyo3_asyncio::async_std::run_until_complete`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/fn.run_until_complete.html).
+
+Because we have to block on one of those functions, we can't use [`#[async_std::main]`](https://docs.rs/async-std/latest/async_std/attr.main.html) or [`#[tokio::main]`](https://docs.rs/tokio/1.1.0/tokio/attr.main.html)
+since it's not a good idea to make long blocking calls during an async function.
+
+> Internally, these `#[main]` proc macros are expanded to something like this:
+> ```rust compile_fail
+> fn main() {
+>     // your async main fn
+>     async fn _main_impl() { /* ... */ }
+>     Runtime::new().block_on(_main_impl());   
+> }
+> ```
+> Making a long blocking call inside the `Future` that's being driven by `block_on` prevents that
+> thread from doing anything else and can spell trouble for some runtimes (also this will actually 
+> deadlock a single-threaded runtime!). Many runtimes have some sort of `spawn_blocking` mechanism 
+> that can avoid this problem, but again that's not something we can use here since we need it to 
+> block on the _main_ thread.
+
+For this reason, `pyo3-asyncio` provides its own set of proc macros to provide you with this 
+initialization. These macros are intended to mirror the initialization of `async-std` and `tokio` 
+while also satisfying the Python runtime's needs.
+
+Here's a full example of PyO3 initialization with the `async-std` runtime:
+```rust no_run
+use pyo3::prelude::*;
+
+#[pyo3_asyncio::async_std::main]
+async fn main() -> PyResult<()> {
+    // PyO3 is initialized - Ready to go
+
+    let fut = Python::with_gil(|py| -> PyResult<_> {
+        let asyncio = py.import("asyncio")?;
+
+        // convert asyncio.sleep into a Rust Future
+        pyo3_asyncio::async_std::into_future(
+            asyncio.call_method1("sleep", (1.into_py(py),))?
+        )
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}
+```
+
+## PyO3 Asyncio in Cargo Tests
+
+The default Cargo Test harness does not currently allow test crates to provide their own `main` 
+function, so there doesn't seem to be a good way to allow Python to gain control over the main
+thread.
+
+We can, however, override the default test harness and provide our own. `pyo3-asyncio` provides some
+utilities to help us do just that! In the following sections, we will provide an overview for 
+constructing a Cargo integration test with `pyo3-asyncio` and adding your tests to it.
+
+### Main Test File
+First, we need to create the test's main file. Although these tests are considered integration
+tests, we cannot put them in the `tests` directory since that is a special directory owned by
+Cargo. Instead, we put our tests in a `pytests` directory.
+
+> The name `pytests` is just a convention. You can name this folder anything you want in your own
+> projects.
+
+We'll also want to provide the test's main function. Most of the functionality that the test harness needs is packed in the [`pyo3_asyncio::testing::main`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/testing/fn.main.html) function. This function will parse the test's CLI arguments, collect and pass the functions marked with [`#[pyo3_asyncio::async_std::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) or [`#[pyo3_asyncio::tokio::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) and pass them into the test harness for running and filtering.
+
+`pytests/test_example.rs` for the `tokio` runtime:
+```rust
+#[pyo3_asyncio::tokio::main]
+async fn main() -> pyo3::PyResult<()> {
+    pyo3_asyncio::testing::main().await
+}
+```
+
+`pytests/test_example.rs` for the `async-std` runtime:
+```rust
+#[pyo3_asyncio::async_std::main]
+async fn main() -> pyo3::PyResult<()> {
+    pyo3_asyncio::testing::main().await
+}
+```
+
+### Cargo Configuration
+Next, we need to add our test file to the Cargo manifest by adding the following section to the
+`Cargo.toml`
+
+```toml
+[[test]]
+name = "test_example"
+path = "pytests/test_example.rs"
+harness = false
+```
+
+Also add the `testing` and `attributes` features to the `pyo3-asyncio` dependency and select your preferred runtime:
+
+```toml
+pyo3-asyncio = { version = "0.13", features = ["testing", "attributes", "async-std-runtime"] }
+```
+
+At this point, you should be able to run the test via `cargo test`
+
+### Adding Tests to the PyO3 Asyncio Test Harness
+
+We can add tests anywhere in the test crate with the runtime's corresponding `#[test]` attribute:
+
+For `async-std` use the [`pyo3_asyncio::async_std::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) attribute:
+```rust
+mod tests {
+    use std::{time::Duration, thread};
+
+    use pyo3::prelude::*;
+
+    // tests can be async
+    #[pyo3_asyncio::async_std::test]
+    async fn test_async_sleep() -> PyResult<()> {
+        async_std::task::sleep(Duration::from_secs(1)).await;
+        Ok(())
+    }
+
+    // they can also be synchronous
+    #[pyo3_asyncio::async_std::test]
+    fn test_blocking_sleep() -> PyResult<()> {
+        thread::sleep(Duration::from_secs(1));
+        Ok(())
+    }
+}
+
+#[pyo3_asyncio::async_std::main]
+async fn main() -> pyo3::PyResult<()> {
+    pyo3_asyncio::testing::main().await
+}
+```
+
+For `tokio` use the [`pyo3_asyncio::tokio::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) attribute:
+```rust
+mod tests {
+    use std::{time::Duration, thread};
+
+    use pyo3::prelude::*;
+
+    // tests can be async
+    #[pyo3_asyncio::tokio::test]
+    async fn test_async_sleep() -> PyResult<()> {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        Ok(())
+    }
+
+    // they can also be synchronous
+    #[pyo3_asyncio::tokio::test]
+    fn test_blocking_sleep() -> PyResult<()> {
+        thread::sleep(Duration::from_secs(1));
+        Ok(())
+    }
+}
+
+#[pyo3_asyncio::tokio::main]
+async fn main() -> pyo3::PyResult<()> {
+    pyo3_asyncio::testing::main().await
+}
+```
+
 ## MSRV
 Currently the MSRV for this library is 1.46.0, _but_ if you don't need to use the `async-std-runtime`
 feature, you can use rust 1.45.0. 

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -6,7 +6,12 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::async_std::task_event_loop()
+                .unwrap()
+                .as_ref(py),
+            asyncio.call_method1("sleep", (1.into_py(py),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -6,12 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future_with_loop(
-            pyo3_asyncio::async_std::task_event_loop()
-                .unwrap()
-                .as_ref(py),
-            asyncio.call_method1("sleep", (1.into_py(py),))?,
-        )
+        pyo3_asyncio::async_std::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -6,7 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::async_std::task_event_loop()
                 .unwrap()
                 .as_ref(py),

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -6,7 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
             asyncio.call_method1("sleep", (1.into_py(py),))?,
         )

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -6,10 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future_with_loop(
-            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
-            asyncio.call_method1("sleep", (1.into_py(py),))?,
-        )
+        pyo3_asyncio::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -6,7 +6,10 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
+            asyncio.call_method1("sleep", (1.into_py(py),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -6,7 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
             asyncio.call_method1("sleep", (1.into_py(py),))?,
         )

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -6,10 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future_with_loop(
-            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
-            asyncio.call_method1("sleep", (1.into_py(py),))?,
-        )
+        pyo3_asyncio::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_current_thread.rs
+++ b/examples/tokio_current_thread.rs
@@ -6,7 +6,10 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
+            asyncio.call_method1("sleep", (1.into_py(py),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -6,7 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
             asyncio.call_method1("sleep", (1.into_py(py),))?,
         )

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -6,10 +6,7 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future_with_loop(
-            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
-            asyncio.call_method1("sleep", (1.into_py(py),))?,
-        )
+        pyo3_asyncio::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
 
     println!("sleeping for 1s");

--- a/examples/tokio_multi_thread.rs
+++ b/examples/tokio_multi_thread.rs
@@ -6,7 +6,10 @@ async fn main() -> PyResult<()> {
         let asyncio = py.import("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
-        pyo3_asyncio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
+            asyncio.call_method1("sleep", (1.into_py(py),))?,
+        )
     })?;
 
     println!("sleeping for 1s");

--- a/pyo3-asyncio-macros/Cargo.toml
+++ b/pyo3-asyncio-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio-macros"
 description = "Proc Macro Attributes for PyO3 Asyncio"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "../README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]

--- a/pyo3-asyncio-macros/Cargo.toml
+++ b/pyo3-asyncio-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio-macros"
 description = "Proc Macro Attributes for PyO3 Asyncio"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "../README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]

--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -146,8 +146,10 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     #body
                 }
 
+                let event_loop = pyo3_asyncio::async_std::task_event_loop().unwrap();
+
                 Box::pin(pyo3_asyncio::async_std::re_exports::spawn_blocking(move || {
-                    #name()
+                    #name(event_loop)
                 }))
             }
         }
@@ -222,8 +224,10 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     #body
                 }
 
-                Box::pin(async {
-                    match pyo3_asyncio::tokio::get_runtime().spawn_blocking(&#name).await {
+                let event_loop = pyo3_asyncio::tokio::task_event_loop().unwrap();
+
+                Box::pin(async move {
+                    match pyo3_asyncio::tokio::get_runtime().spawn_blocking(move || #name(event_loop)).await {
                         Ok(result) => result,
                         Err(e) => {
                             assert!(e.is_panic());

--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -146,7 +146,9 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     #body
                 }
 
-                let event_loop = pyo3_asyncio::async_std::task_event_loop().unwrap();
+                let event_loop = Python::with_gil(|py| {
+                    pyo3_asyncio::async_std::task_event_loop(py).unwrap().into()
+                });
 
                 Box::pin(pyo3_asyncio::async_std::re_exports::spawn_blocking(move || {
                     #name(event_loop)
@@ -224,7 +226,9 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     #body
                 }
 
-                let event_loop = pyo3_asyncio::tokio::task_event_loop().unwrap();
+                let event_loop = Python::with_gil(|py| {
+                    pyo3_asyncio::tokio::task_event_loop(py).unwrap().into()
+                });
 
                 Box::pin(async move {
                     match pyo3_asyncio::tokio::get_runtime().spawn_blocking(move || #name(event_loop)).await {

--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -50,15 +50,11 @@ pub fn async_std_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             pyo3::Python::with_gil(|py| {
-                pyo3_asyncio::with_runtime(py, || {
-                    pyo3_asyncio::async_std::run_until_complete(py, main())?;
-
-                    Ok(())
-                })
-                .map_err(|e| {
-                    e.print_and_set_sys_last_vars(py);
-                })
-                .unwrap();
+                pyo3_asyncio::async_std::run(py, main())
+                    .map_err(|e| {
+                        e.print_and_set_sys_last_vars(py);
+                    })
+                    .unwrap();
             });
         }
     };

--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -153,7 +153,7 @@ pub fn async_std_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {
                 let event_loop = Python::with_gil(|py| {
-                    pyo3_asyncio::async_std::task_event_loop(py).unwrap().into()
+                    pyo3_asyncio::async_std::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(pyo3_asyncio::async_std::re_exports::spawn_blocking(move || {
                     #name(event_loop)
@@ -258,7 +258,7 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {
                 let event_loop = Python::with_gil(|py| {
-                    pyo3_asyncio::tokio::task_event_loop(py).unwrap().into()
+                    pyo3_asyncio::tokio::get_current_loop(py).unwrap().into()
                 });
                 Box::pin(async move {
                     match pyo3_asyncio::tokio::get_runtime().spawn_blocking(move || #name(event_loop)).await {

--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -49,6 +49,8 @@ pub fn async_std_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #body
             }
 
+            pyo3::prepare_freethreaded_python();
+
             pyo3::Python::with_gil(|py| {
                 pyo3_asyncio::async_std::run(py, main())
                     .map_err(|e| {

--- a/pyo3-asyncio-macros/src/tokio.rs
+++ b/pyo3-asyncio-macros/src/tokio.rs
@@ -257,15 +257,11 @@ fn parse_knobs(
             #rt_init
 
             pyo3::Python::with_gil(|py| {
-                pyo3_asyncio::with_runtime(py, || {
-                    pyo3_asyncio::tokio::run_until_complete(py, main())?;
-
-                    Ok(())
-                })
-                .map_err(|e| {
-                    e.print_and_set_sys_last_vars(py);
-                })
-                .unwrap();
+                pyo3_asyncio::tokio::run(py, main())
+                    .map_err(|e| {
+                        e.print_and_set_sys_last_vars(py);
+                    })
+                    .unwrap();
             });
         }
     };

--- a/pyo3-asyncio-macros/src/tokio.rs
+++ b/pyo3-asyncio-macros/src/tokio.rs
@@ -247,6 +247,8 @@ fn parse_knobs(
                 #body
             }
 
+            pyo3::prepare_freethreaded_python();
+
             pyo3_asyncio::tokio::init(
                 #rt
                     .enable_all()

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -17,7 +17,7 @@ pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
         let test_mod =
             PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?;
 
-        pyo3_asyncio::into_future(
+        pyo3_asyncio::into_future_with_loop(
             event_loop.as_ref(py),
             test_mod.call_method1("py_sleep", (1.into_py(py),))?,
         )
@@ -47,7 +47,7 @@ pub(super) async fn test_other_awaitables(event_loop: PyObject) -> PyResult<()> 
             ),
         )?;
 
-        pyo3_asyncio::into_future(event_loop.as_ref(py), task)
+        pyo3_asyncio::into_future_with_loop(event_loop.as_ref(py), task)
     })?;
 
     fut.await?;

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -28,6 +28,19 @@ pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
     Ok(())
 }
 
+pub(super) async fn test_into_future_0_13() -> PyResult<()> {
+    let fut = Python::with_gil(|py| {
+        let test_mod =
+            PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?;
+
+        pyo3_asyncio::into_future(test_mod.call_method1("py_sleep", (1.into_py(py),))?)
+    })?;
+
+    fut.await?;
+
+    Ok(())
+}
+
 pub(super) fn test_blocking_sleep() -> PyResult<()> {
     thread::sleep(Duration::from_secs(1));
     Ok(())

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -12,12 +12,15 @@ async def sleep_for_1s(sleep_for):
     await sleep_for(1)
 "#;
 
-pub(super) async fn test_into_future() -> PyResult<()> {
+pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
     let fut = Python::with_gil(|py| {
         let test_mod =
             PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?;
 
-        pyo3_asyncio::into_future(test_mod.call_method1("py_sleep", (1.into_py(py),))?)
+        pyo3_asyncio::into_future(
+            event_loop.as_ref(py),
+            test_mod.call_method1("py_sleep", (1.into_py(py),))?,
+        )
     })?;
 
     fut.await?;
@@ -30,13 +33,13 @@ pub(super) fn test_blocking_sleep() -> PyResult<()> {
     Ok(())
 }
 
-pub(super) async fn test_other_awaitables() -> PyResult<()> {
+pub(super) async fn test_other_awaitables(event_loop: PyObject) -> PyResult<()> {
     let fut = Python::with_gil(|py| {
         let functools = py.import("functools")?;
         let time = py.import("time")?;
 
         // spawn a blocking sleep in the threadpool executor - returns a task, not a coroutine
-        let task = pyo3_asyncio::get_event_loop(py).call_method1(
+        let task = event_loop.as_ref(py).call_method1(
             "run_in_executor",
             (
                 py.None(),
@@ -44,7 +47,7 @@ pub(super) async fn test_other_awaitables() -> PyResult<()> {
             ),
         )?;
 
-        pyo3_asyncio::into_future(task)
+        pyo3_asyncio::into_future(event_loop.as_ref(py), task)
     })?;
 
     fut.await?;

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -28,6 +28,7 @@ pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
     Ok(())
 }
 
+#[allow(deprecated)]
 pub(super) async fn test_into_future_0_13() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
         let test_mod =

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -54,11 +54,3 @@ pub(super) async fn test_other_awaitables(event_loop: PyObject) -> PyResult<()> 
 
     Ok(())
 }
-
-pub(super) fn test_init_twice() -> PyResult<()> {
-    // try_init has already been called in test main - ensure a second call doesn't mess the other
-    // tests up
-    Python::with_gil(|py| pyo3_asyncio::try_init(py))?;
-
-    Ok(())
-}

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -76,11 +76,6 @@ async fn test_other_awaitables() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::async_std::test]
-fn test_init_twice(_event_loop: PyObject) -> PyResult<()> {
-    common::test_init_twice()
-}
-
-#[pyo3_asyncio::async_std::test]
 async fn test_panic() -> PyResult<()> {
     let fut = Python::with_gil(|py| -> PyResult<_> {
         pyo3_asyncio::async_std::into_future(

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -98,7 +98,9 @@ fn test_blocking_sleep() -> PyResult<()> {
 #[pyo3_asyncio::async_std::test]
 async fn test_into_future() -> PyResult<()> {
     common::test_into_future(Python::with_gil(|py| {
-        pyo3_asyncio::async_std::task_event_loop(py).unwrap().into()
+        pyo3_asyncio::async_std::get_current_loop(py)
+            .unwrap()
+            .into()
     }))
     .await
 }
@@ -111,7 +113,9 @@ async fn test_into_future_0_13() -> PyResult<()> {
 #[pyo3_asyncio::async_std::test]
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables(Python::with_gil(|py| {
-        pyo3_asyncio::async_std::task_event_loop(py).unwrap().into()
+        pyo3_asyncio::async_std::get_current_loop(py)
+            .unwrap()
+            .into()
     }))
     .await
 }

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -159,6 +159,8 @@ async fn test_local_future_into_py() -> PyResult<()> {
 
 #[allow(deprecated)]
 fn main() -> pyo3::PyResult<()> {
+    pyo3::prepare_freethreaded_python();
+
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API
         pyo3_asyncio::try_init(py)?;

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -136,15 +136,6 @@ async fn test_panic() -> PyResult<()> {
     }
 }
 
-#[allow(deprecated)]
-fn main() -> pyo3::PyResult<()> {
-    Python::with_gil(|py| {
-        // into_coroutine requires the 0.13 API
-        pyo3_asyncio::try_init(py)?;
-        pyo3_asyncio::async_std::run(py, pyo3_asyncio::testing::main())
-    })
-}
-
 #[pyo3_asyncio::async_std::test]
 async fn test_local_future_into_py() -> PyResult<()> {
     Python::with_gil(|py| {
@@ -160,4 +151,13 @@ async fn test_local_future_into_py() -> PyResult<()> {
     .await?;
 
     Ok(())
+}
+
+#[allow(deprecated)]
+fn main() -> pyo3::PyResult<()> {
+    Python::with_gil(|py| {
+        // into_coroutine requires the 0.13 API
+        pyo3_asyncio::try_init(py)?;
+        pyo3_asyncio::async_std::run(py, pyo3_asyncio::testing::main())
+    })
 }

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -68,6 +68,11 @@ async fn test_into_future() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::async_std::test]
+async fn test_into_future_0_13() -> PyResult<()> {
+    common::test_into_future_0_13().await
+}
+
+#[pyo3_asyncio::async_std::test]
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables(Python::with_gil(|py| {
         pyo3_asyncio::async_std::task_event_loop(py).unwrap().into()

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -187,7 +187,7 @@ async fn test_cancel() -> PyResult<()> {
     {
         Python::with_gil(|py| -> PyResult<()> {
             assert!(py
-                .import("asyncio.exceptions")?
+                .import("asyncio")?
                 .getattr("CancelledError")?
                 .downcast::<PyType>()
                 .unwrap()

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -9,7 +9,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
     let secs = secs.extract()?;
 
-    pyo3_asyncio::async_std::into_coroutine(pyo3_asyncio::get_event_loop(py)?, async move {
+    pyo3_asyncio::async_std::into_coroutine(py, async move {
         task::sleep(Duration::from_secs(secs)).await;
         Python::with_gil(|py| Ok(py.None()))
     })
@@ -83,9 +83,8 @@ fn test_init_twice(_event_loop: PyObject) -> PyResult<()> {
 #[pyo3_asyncio::async_std::test]
 async fn test_panic() -> PyResult<()> {
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        let event_loop = pyo3_asyncio::async_std::task_event_loop(py).unwrap();
         pyo3_asyncio::async_std::into_future(
-            pyo3_asyncio::async_std::into_coroutine(event_loop, async {
+            pyo3_asyncio::async_std::into_coroutine(py, async {
                 panic!("this panic was intentional!")
             })?
             .as_ref(py),

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -9,7 +9,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
     let secs = secs.extract()?;
 
-    pyo3_asyncio::async_std::into_coroutine(py, async move {
+    pyo3_asyncio::async_std::into_coroutine(pyo3_asyncio::get_event_loop(py)?, async move {
         task::sleep(Duration::from_secs(secs)).await;
         Python::with_gil(|py| Ok(py.None()))
     })
@@ -30,6 +30,9 @@ async fn test_into_coroutine() -> PyResult<()> {
         )?;
 
         pyo3_asyncio::into_future(
+            pyo3_asyncio::async_std::task_event_loop()
+                .unwrap()
+                .as_ref(py),
             test_mod.call_method1("sleep_for_1s", (sleeper_mod.getattr("sleep_for")?,))?,
         )
     })?;
@@ -47,7 +50,12 @@ async fn test_async_sleep() -> PyResult<()> {
     task::sleep(Duration::from_secs(1)).await;
 
     Python::with_gil(|py| {
-        pyo3_asyncio::into_future(asyncio.as_ref(py).call_method1("sleep", (1.0,))?)
+        pyo3_asyncio::into_future(
+            pyo3_asyncio::async_std::task_event_loop()
+                .unwrap()
+                .as_ref(py),
+            asyncio.as_ref(py).call_method1("sleep", (1.0,))?,
+        )
     })?
     .await?;
 
@@ -55,22 +63,22 @@ async fn test_async_sleep() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::async_std::test]
-fn test_blocking_sleep() -> PyResult<()> {
+fn test_blocking_sleep(_event_loop: PyObject) -> PyResult<()> {
     common::test_blocking_sleep()
 }
 
 #[pyo3_asyncio::async_std::test]
 async fn test_into_future() -> PyResult<()> {
-    common::test_into_future().await
+    common::test_into_future(pyo3_asyncio::async_std::task_event_loop().unwrap()).await
 }
 
 #[pyo3_asyncio::async_std::test]
 async fn test_other_awaitables() -> PyResult<()> {
-    common::test_other_awaitables().await
+    common::test_other_awaitables(pyo3_asyncio::async_std::task_event_loop().unwrap()).await
 }
 
 #[pyo3_asyncio::async_std::test]
-fn test_init_twice() -> PyResult<()> {
+fn test_init_twice(_event_loop: PyObject) -> PyResult<()> {
     common::test_init_twice()
 }
 
@@ -84,12 +92,15 @@ async fn test_local_coroutine() -> PyResult<()> {
     Python::with_gil(|py| {
         let non_send_secs = Rc::new(1);
 
-        let py_future = pyo3_asyncio::async_std::local_future_into_py(py, async move {
-            async_std::task::sleep(Duration::from_secs(*non_send_secs)).await;
-            Ok(Python::with_gil(|py| py.None()))
-        })?;
+        let event_loop = pyo3_asyncio::async_std::task_event_loop().unwrap();
 
-        pyo3_asyncio::into_future(py_future)
+        let py_future =
+            pyo3_asyncio::async_std::local_future_into_py(event_loop.as_ref(py), async move {
+                async_std::task::sleep(Duration::from_secs(*non_send_secs)).await;
+                Ok(Python::with_gil(|py| py.None()))
+            })?;
+
+        pyo3_asyncio::into_future(event_loop.as_ref(py), py_future.as_ref(py))
     })?
     .await?;
 

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -100,7 +100,7 @@ async fn test_local_coroutine() -> PyResult<()> {
                 Ok(Python::with_gil(|py| py.None()))
             })?;
 
-        pyo3_asyncio::into_future(event_loop.as_ref(py), py_future.as_ref(py))
+        pyo3_asyncio::into_future(event_loop.as_ref(py), py_future)
     })?
     .await?;
 

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -13,16 +13,21 @@ fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
 fn main() {
     Python::with_gil(|py| {
         pyo3_asyncio::with_runtime(py, || {
+            let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+
             async_std::task::spawn(async move {
                 async_std::task::sleep(Duration::from_secs(1)).await;
 
                 Python::with_gil(|py| {
-                    let event_loop = pyo3_asyncio::get_event_loop(py);
-
                     event_loop
+                        .as_ref(py)
                         .call_method1(
                             "call_soon_threadsafe",
-                            (event_loop.getattr("stop").map_err(dump_err(py)).unwrap(),),
+                            (event_loop
+                                .as_ref(py)
+                                .getattr("stop")
+                                .map_err(dump_err(py))
+                                .unwrap(),),
                         )
                         .map_err(dump_err(py))
                         .unwrap();

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -10,7 +10,7 @@ fn dump_err(py: Python, e: PyErr) {
 
 fn main() {
     Python::with_gil(|py| {
-        let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+        let event_loop = PyObject::from(pyo3_asyncio::get_running_loop(py).unwrap());
 
         async_std::task::spawn(async move {
             async_std::task::sleep(Duration::from_secs(1)).await;

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -2,44 +2,40 @@ use std::time::Duration;
 
 use pyo3::prelude::*;
 
-fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
-    move |e| {
-        // We can't display Python exceptions via std::fmt::Display,
-        // so print the error here manually.
-        e.print_and_set_sys_last_vars(py);
-    }
+fn dump_err(py: Python, e: PyErr) {
+    // We can't display Python exceptions via std::fmt::Display,
+    // so print the error here manually.
+    e.print_and_set_sys_last_vars(py);
 }
 
 fn main() {
     Python::with_gil(|py| {
-        pyo3_asyncio::with_runtime(py, || {
-            let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+        let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
 
-            async_std::task::spawn(async move {
-                async_std::task::sleep(Duration::from_secs(1)).await;
+        async_std::task::spawn(async move {
+            async_std::task::sleep(Duration::from_secs(1)).await;
 
-                Python::with_gil(|py| {
-                    event_loop
-                        .as_ref(py)
-                        .call_method1(
-                            "call_soon_threadsafe",
-                            (event_loop
-                                .as_ref(py)
-                                .getattr("stop")
-                                .map_err(dump_err(py))
-                                .unwrap(),),
-                        )
-                        .map_err(dump_err(py))
-                        .unwrap();
-                })
-            });
+            Python::with_gil(|py| {
+                event_loop
+                    .as_ref(py)
+                    .call_method1(
+                        "call_soon_threadsafe",
+                        (event_loop
+                            .as_ref(py)
+                            .getattr("stop")
+                            .map_err(|e| dump_err(py, e))
+                            .unwrap(),),
+                    )
+                    .map_err(|e| dump_err(py, e))
+                    .unwrap();
+            })
+        });
 
-            pyo3_asyncio::run_forever(py)?;
+        pyo3_asyncio::run_forever(py)?;
 
-            println!("test test_run_forever ... ok");
-            Ok(())
-        })
-        .map_err(dump_err(py))
-        .unwrap();
+        println!("test test_run_forever ... ok");
+        Ok(())
     })
+    .map_err(|e| Python::with_gil(|py| dump_err(py, e)))
+    .unwrap()
 }

--- a/pytests/test_async_std_run_forever.rs
+++ b/pytests/test_async_std_run_forever.rs
@@ -9,6 +9,8 @@ fn dump_err(py: Python, e: PyErr) {
 }
 
 fn main() {
+    pyo3::prepare_freethreaded_python();
+
     Python::with_gil(|py| {
         let asyncio = py.import("asyncio")?;
 

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -10,7 +10,15 @@ fn main() -> pyo3::PyResult<()> {
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API
         pyo3_asyncio::try_init(py)?;
-        pyo3_asyncio::tokio::init_current_thread();
+
+        let mut builder = tokio::runtime::Builder::new_current_thread();
+        builder.enable_all();
+
+        pyo3_asyncio::tokio::init(builder);
+        std::thread::spawn(move || {
+            pyo3_asyncio::tokio::get_runtime().block_on(futures::future::pending::<()>());
+        });
+
         pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main())
     })
 }

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -5,6 +5,8 @@ use pyo3::prelude::*;
 
 #[allow(deprecated)]
 fn main() -> pyo3::PyResult<()> {
+    pyo3::prepare_freethreaded_python();
+
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API
         pyo3_asyncio::try_init(py)?;

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -3,6 +3,7 @@ mod tokio_asyncio;
 
 use pyo3::prelude::*;
 
+#[allow(deprecated)]
 fn main() -> pyo3::PyResult<()> {
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -1,7 +1,13 @@
 mod common;
 mod tokio_asyncio;
 
-#[pyo3_asyncio::tokio::main(flavor = "current_thread")]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
+use pyo3::prelude::*;
+
+fn main() -> pyo3::PyResult<()> {
+    Python::with_gil(|py| {
+        // into_coroutine requires the 0.13 API
+        pyo3_asyncio::try_init(py)?;
+        pyo3_asyncio::tokio::init_current_thread();
+        pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main())
+    })
 }

--- a/pytests/test_tokio_current_thread_run_forever.rs
+++ b/pytests/test_tokio_current_thread_run_forever.rs
@@ -1,6 +1,7 @@
 mod tokio_run_forever;
 
 fn main() {
+    pyo3::prepare_freethreaded_python();
     pyo3_asyncio::tokio::init_current_thread();
 
     tokio_run_forever::test_main();

--- a/pytests/test_tokio_current_thread_run_forever.rs
+++ b/pytests/test_tokio_current_thread_run_forever.rs
@@ -2,7 +2,14 @@ mod tokio_run_forever;
 
 fn main() {
     pyo3::prepare_freethreaded_python();
-    pyo3_asyncio::tokio::init_current_thread();
+
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+    builder.enable_all();
+
+    pyo3_asyncio::tokio::init(builder);
+    std::thread::spawn(move || {
+        pyo3_asyncio::tokio::get_runtime().block_on(futures::future::pending::<()>());
+    });
 
     tokio_run_forever::test_main();
 }

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -5,6 +5,8 @@ use pyo3::prelude::*;
 
 #[allow(deprecated)]
 fn main() -> pyo3::PyResult<()> {
+    pyo3::prepare_freethreaded_python();
+
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API
         pyo3_asyncio::try_init(py)?;

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -3,6 +3,7 @@ mod tokio_asyncio;
 
 use pyo3::prelude::*;
 
+#[allow(deprecated)]
 fn main() -> pyo3::PyResult<()> {
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -1,7 +1,13 @@
 mod common;
 mod tokio_asyncio;
 
-#[pyo3_asyncio::tokio::main]
-async fn main() -> pyo3::PyResult<()> {
-    pyo3_asyncio::testing::main().await
+use pyo3::prelude::*;
+
+fn main() -> pyo3::PyResult<()> {
+    Python::with_gil(|py| {
+        // into_coroutine requires the 0.13 API
+        pyo3_asyncio::try_init(py)?;
+        pyo3_asyncio::tokio::init_multi_thread();
+        pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main())
+    })
 }

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -10,7 +10,6 @@ fn main() -> pyo3::PyResult<()> {
     Python::with_gil(|py| {
         // into_coroutine requires the 0.13 API
         pyo3_asyncio::try_init(py)?;
-        pyo3_asyncio::tokio::init_multi_thread();
         pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main())
     })
 }

--- a/pytests/test_tokio_multi_thread_run_forever.rs
+++ b/pytests/test_tokio_multi_thread_run_forever.rs
@@ -2,8 +2,5 @@ mod tokio_run_forever;
 
 fn main() {
     pyo3::prepare_freethreaded_python();
-
-    pyo3_asyncio::tokio::init_multi_thread();
-
     tokio_run_forever::test_main();
 }

--- a/pytests/test_tokio_multi_thread_run_forever.rs
+++ b/pytests/test_tokio_multi_thread_run_forever.rs
@@ -1,6 +1,8 @@
 mod tokio_run_forever;
 
 fn main() {
+    pyo3::prepare_freethreaded_python();
+
     pyo3_asyncio::tokio::init_multi_thread();
 
     tokio_run_forever::test_main();

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -125,16 +125,6 @@ async fn test_other_awaitables() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::tokio::test]
-fn test_init_tokio_twice() -> PyResult<()> {
-    // tokio has already been initialized in test main. call these functions to
-    // make sure they don't cause problems with the other tests.
-    pyo3_asyncio::tokio::init_multi_thread_once();
-    pyo3_asyncio::tokio::init_current_thread_once();
-
-    Ok(())
-}
-
-#[pyo3_asyncio::tokio::test]
 fn test_local_future_into_py(event_loop: PyObject) -> PyResult<()> {
     tokio::task::LocalSet::new().block_on(pyo3_asyncio::tokio::get_runtime(), async {
         Python::with_gil(|py| {

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -1,6 +1,11 @@
 use std::{rc::Rc, time::Duration};
 
-use pyo3::{prelude::*, types::PyType, wrap_pyfunction};
+use pyo3::{
+    prelude::*,
+    proc_macro::pymodule,
+    types::{IntoPyDict, PyType},
+    wrap_pyfunction, wrap_pymodule,
+};
 
 use crate::common;
 
@@ -26,8 +31,9 @@ fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
 }
 
 #[pyo3_asyncio::tokio::test]
-async fn test_into_coroutine() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
+fn test_into_coroutine() -> PyResult<()> {
+    #[allow(deprecated)]
+    Python::with_gil(|py| {
         let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
 
         sleeper_mod.add_wrapped(wrap_pyfunction!(sleep_into_coroutine))?;
@@ -39,15 +45,18 @@ async fn test_into_coroutine() -> PyResult<()> {
             "test_into_coroutine_mod",
         )?;
 
-        pyo3_asyncio::tokio::into_future(test_mod.call_method1(
+        let fut = pyo3_asyncio::into_future(test_mod.call_method1(
             "sleep_for_1s",
             (sleeper_mod.getattr("sleep_into_coroutine")?,),
-        )?)
-    })?;
+        )?)?;
 
-    fut.await?;
+        pyo3_asyncio::tokio::run_until_complete(pyo3_asyncio::get_event_loop(py), async move {
+            fut.await?;
+            Ok(())
+        })?;
 
-    Ok(())
+        Ok(())
+    })
 }
 
 #[pyo3_asyncio::tokio::test]
@@ -197,4 +206,49 @@ async fn test_cancel() -> PyResult<()> {
     }
 
     Ok(())
+}
+/// This module is implemented in Rust.
+#[pymodule]
+fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+    #![allow(deprecated)]
+    #[pyfn(m, "sleep")]
+    fn sleep(py: Python) -> PyResult<&PyAny> {
+        pyo3_asyncio::async_std::future_into_py(py, async move {
+            async_std::task::sleep(Duration::from_millis(500)).await;
+            Ok(Python::with_gil(|py| py.None()))
+        })
+    }
+
+    Ok(())
+}
+
+const TEST_CODE: &str = r#"
+async def main():
+    return await test_mod.sleep()
+
+asyncio.run(main())
+"#;
+
+#[pyo3_asyncio::tokio::test]
+fn test_multiple_asyncio_run() -> PyResult<()> {
+    Python::with_gil(|py| {
+        pyo3_asyncio::tokio::run(py, async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(())
+        })?;
+        pyo3_asyncio::tokio::run(py, async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(())
+        })?;
+
+        let d = [
+            ("asyncio", py.import("asyncio")?.into()),
+            ("test_mod", wrap_pymodule!(test_mod)(py)),
+        ]
+        .into_py_dict(py);
+
+        py.run(TEST_CODE, Some(d), None)?;
+        py.run(TEST_CODE, Some(d), None)?;
+        Ok(())
+    })
 }

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -194,7 +194,7 @@ async fn test_cancel() -> PyResult<()> {
     {
         Python::with_gil(|py| -> PyResult<()> {
             assert!(py
-                .import("asyncio.exceptions")?
+                .import("asyncio")?
                 .getattr("CancelledError")?
                 .downcast::<PyType>()
                 .unwrap()

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -75,11 +75,6 @@ async fn test_other_awaitables() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::tokio::test]
-fn test_init_twice(_event_loop: PyObject) -> PyResult<()> {
-    common::test_init_twice()
-}
-
-#[pyo3_asyncio::tokio::test]
 fn test_init_tokio_twice(_event_loop: PyObject) -> PyResult<()> {
     // tokio has already been initialized in test main. call these functions to
     // make sure they don't cause problems with the other tests.

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -97,7 +97,7 @@ fn test_blocking_sleep() -> PyResult<()> {
 #[pyo3_asyncio::tokio::test]
 async fn test_into_future() -> PyResult<()> {
     common::test_into_future(Python::with_gil(|py| {
-        pyo3_asyncio::tokio::task_event_loop(py).unwrap().into()
+        pyo3_asyncio::tokio::get_current_loop(py).unwrap().into()
     }))
     .await
 }
@@ -110,7 +110,7 @@ async fn test_into_future_0_13() -> PyResult<()> {
 #[pyo3_asyncio::tokio::test]
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables(Python::with_gil(|py| {
-        pyo3_asyncio::tokio::task_event_loop(py).unwrap().into()
+        pyo3_asyncio::tokio::get_current_loop(py).unwrap().into()
     }))
     .await
 }

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -103,7 +103,7 @@ fn test_local_set_coroutine(event_loop: PyObject) -> PyResult<()> {
                     Ok(Python::with_gil(|py| py.None()))
                 })?;
 
-            pyo3_asyncio::into_future(event_loop.as_ref(py), py_future.as_ref(py))
+            pyo3_asyncio::into_future(event_loop.as_ref(py), py_future)
         })?
         .await?;
 

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -70,6 +70,11 @@ async fn test_into_future() -> PyResult<()> {
 }
 
 #[pyo3_asyncio::tokio::test]
+async fn test_into_future_0_13() -> PyResult<()> {
+    common::test_into_future_0_13().await
+}
+
+#[pyo3_asyncio::tokio::test]
 async fn test_other_awaitables() -> PyResult<()> {
     common::test_other_awaitables(Python::with_gil(|py| {
         pyo3_asyncio::tokio::task_event_loop(py).unwrap().into()

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -8,7 +8,7 @@ use crate::common;
 fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
     let secs = secs.extract()?;
 
-    pyo3_asyncio::tokio::into_coroutine(pyo3_asyncio::get_event_loop(py)?, async move {
+    pyo3_asyncio::tokio::into_coroutine(py, async move {
         tokio::time::sleep(Duration::from_secs(secs)).await;
         Python::with_gil(|py| Ok(py.None()))
     })
@@ -114,9 +114,8 @@ fn test_local_set_coroutine(event_loop: PyObject) -> PyResult<()> {
 #[pyo3_asyncio::tokio::test]
 async fn test_panic() -> PyResult<()> {
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        let event_loop = pyo3_asyncio::tokio::task_event_loop(py).unwrap();
         pyo3_asyncio::tokio::into_future(
-            pyo3_asyncio::tokio::into_coroutine(event_loop, async {
+            pyo3_asyncio::tokio::into_coroutine(py, async {
                 panic!("this panic was intentional!")
             })?
             .as_ref(py),

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -2,44 +2,40 @@ use std::time::Duration;
 
 use pyo3::prelude::*;
 
-fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
-    move |e| {
-        // We can't display Python exceptions via std::fmt::Display,
-        // so print the error here manually.
-        e.print_and_set_sys_last_vars(py);
-    }
+fn dump_err(py: Python<'_>, e: PyErr) {
+    // We can't display Python exceptions via std::fmt::Display,
+    // so print the error here manually.
+    e.print_and_set_sys_last_vars(py);
 }
 
 pub(super) fn test_main() {
     Python::with_gil(|py| {
-        pyo3_asyncio::with_runtime(py, || {
-            let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+        let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
 
-            pyo3_asyncio::tokio::get_runtime().spawn(async move {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+        pyo3_asyncio::tokio::get_runtime().spawn(async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
 
-                Python::with_gil(|py| {
-                    event_loop
-                        .as_ref(py)
-                        .call_method1(
-                            "call_soon_threadsafe",
-                            (event_loop
-                                .as_ref(py)
-                                .getattr("stop")
-                                .map_err(dump_err(py))
-                                .unwrap(),),
-                        )
-                        .map_err(dump_err(py))
-                        .unwrap();
-                })
-            });
+            Python::with_gil(|py| {
+                event_loop
+                    .as_ref(py)
+                    .call_method1(
+                        "call_soon_threadsafe",
+                        (event_loop
+                            .as_ref(py)
+                            .getattr("stop")
+                            .map_err(|e| dump_err(py, e))
+                            .unwrap(),),
+                    )
+                    .map_err(|e| dump_err(py, e))
+                    .unwrap();
+            })
+        });
 
-            pyo3_asyncio::run_forever(py)?;
+        pyo3_asyncio::run_forever(py)?;
 
-            println!("test test_run_forever ... ok");
-            Ok(())
-        })
-        .map_err(dump_err(py))
-        .unwrap();
+        println!("test test_run_forever ... ok");
+        Ok(())
     })
+    .map_err(|e| Python::with_gil(|py| dump_err(py, e)))
+    .unwrap();
 }

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -10,17 +10,22 @@ fn dump_err(py: Python<'_>, e: PyErr) {
 
 pub(super) fn test_main() {
     Python::with_gil(|py| {
-        let event_loop = PyObject::from(pyo3_asyncio::get_running_loop(py).unwrap());
+        let asyncio = py.import("asyncio")?;
+
+        let event_loop = asyncio.call_method0("new_event_loop")?;
+        asyncio.call_method1("set_event_loop", (event_loop,))?;
+
+        let event_loop_hdl = PyObject::from(event_loop);
 
         pyo3_asyncio::tokio::get_runtime().spawn(async move {
             tokio::time::sleep(Duration::from_secs(1)).await;
 
             Python::with_gil(|py| {
-                event_loop
+                event_loop_hdl
                     .as_ref(py)
                     .call_method1(
                         "call_soon_threadsafe",
-                        (event_loop
+                        (event_loop_hdl
                             .as_ref(py)
                             .getattr("stop")
                             .map_err(|e| dump_err(py, e))
@@ -31,7 +36,7 @@ pub(super) fn test_main() {
             })
         });
 
-        pyo3_asyncio::run_forever(py)?;
+        event_loop.call_method0("run_forever")?;
 
         println!("test test_run_forever ... ok");
         Ok(())

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -10,7 +10,7 @@ fn dump_err(py: Python<'_>, e: PyErr) {
 
 pub(super) fn test_main() {
     Python::with_gil(|py| {
-        let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+        let event_loop = PyObject::from(pyo3_asyncio::get_running_loop(py).unwrap());
 
         pyo3_asyncio::tokio::get_runtime().spawn(async move {
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/pytests/tokio_run_forever/mod.rs
+++ b/pytests/tokio_run_forever/mod.rs
@@ -13,16 +13,21 @@ fn dump_err(py: Python<'_>) -> impl FnOnce(PyErr) + '_ {
 pub(super) fn test_main() {
     Python::with_gil(|py| {
         pyo3_asyncio::with_runtime(py, || {
+            let event_loop = PyObject::from(pyo3_asyncio::get_event_loop(py).unwrap());
+
             pyo3_asyncio::tokio::get_runtime().spawn(async move {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
                 Python::with_gil(|py| {
-                    let event_loop = pyo3_asyncio::get_event_loop(py);
-
                     event_loop
+                        .as_ref(py)
                         .call_method1(
                             "call_soon_threadsafe",
-                            (event_loop.getattr("stop").map_err(dump_err(py)).unwrap(),),
+                            (event_loop
+                                .as_ref(py)
+                                .getattr("stop")
+                                .map_err(dump_err(py))
+                                .unwrap(),),
                         )
                         .map_err(dump_err(py))
                         .unwrap();

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -87,6 +87,7 @@ impl SpawnLocalExt for AsyncStdRuntime {
     }
 }
 
+/// Set the task local event loop for the given future
 pub async fn scope<F, R>(event_loop: PyObject, fut: F) -> R
 where
     F: Future<Output = R> + Send + 'static,
@@ -94,6 +95,7 @@ where
     AsyncStdRuntime::scope(event_loop, fut).await
 }
 
+/// Set the task local event loop for the given !Send future
 pub async fn scope_local<F, R>(event_loop: PyObject, fut: F) -> R
 where
     F: Future<Output = R> + 'static,
@@ -198,7 +200,7 @@ where
 ///     // Rc is non-send so it cannot be passed into pyo3_asyncio::async_std::into_coroutine
 ///     let secs = Rc::new(secs);
 ///
-///     Ok(pyo3_asyncio::async_std::local_future_into_py(
+///     Ok(pyo3_asyncio::async_std::local_future_into_py_with_loop(
 ///         pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py),
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
@@ -212,7 +214,7 @@ where
 /// async fn main() -> PyResult<()> {
 ///     Python::with_gil(|py| {
 ///         let py_future = sleep_for(py, 1)?;
-///         pyo3_asyncio::into_future(
+///         pyo3_asyncio::into_future_with_loop(
 ///             pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py),
 ///             py_future.as_ref(py)
 ///         )
@@ -224,9 +226,9 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    generic::local_future_into_py::<AsyncStdRuntime, _>(event_loop, fut)
+    generic::local_future_into_py_with_loop::<AsyncStdRuntime, _>(event_loop, fut)
 }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -230,7 +230,7 @@ where
 /// ```
 #[deprecated(
     since = "0.14.0",
-    note = "Use the pyo3_asyncio::async_std::future_into_py instead"
+    note = "Use the pyo3_asyncio::async_std::future_into_py instead\n\t\t(see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
 )]
 #[allow(deprecated)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -3,9 +3,12 @@ use std::{any::Any, future::Future, panic::AssertUnwindSafe, pin::Pin};
 use async_std::task;
 use futures::prelude::*;
 use once_cell::unsync::OnceCell;
-use pyo3::prelude::*;
+use pyo3::{prelude::*, PyNativeType};
 
-use crate::generic::{self, JoinError, Runtime, SpawnLocalExt};
+use crate::{
+    generic::{self, JoinError, Runtime, SpawnLocalExt},
+    into_future_with_loop,
+};
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>attributes</code></span>
 /// re-exports for macros
@@ -50,8 +53,8 @@ impl Runtime for AsyncStdRuntime {
         EVENT_LOOP.with(|c| c.set(event_loop).unwrap());
         Box::pin(fut)
     }
-    fn get_task_event_loop() -> Option<PyObject> {
-        EVENT_LOOP.with(|c| c.get().map(|event_loop| event_loop.clone()))
+    fn get_task_event_loop(py: Python) -> Option<&PyAny> {
+        EVENT_LOOP.with(|c| c.get().map(|event_loop| event_loop.clone().into_ref(py)))
     }
 
     fn spawn<F>(fut: F) -> Self::JoinHandle
@@ -103,9 +106,14 @@ where
     AsyncStdRuntime::scope_local(event_loop, fut).await
 }
 
+/// Get the current event loop from either Python or Rust async task local context
+pub fn current_event_loop(py: Python) -> PyResult<&PyAny> {
+    generic::current_event_loop::<AsyncStdRuntime>(py)
+}
+
 /// Get the task local event loop for the current async_std task
-pub fn task_event_loop() -> Option<PyObject> {
-    AsyncStdRuntime::get_task_event_loop()
+pub fn task_event_loop(py: Python) -> Option<&PyAny> {
+    AsyncStdRuntime::get_task_event_loop(py)
 }
 
 /// Run the event loop until the given Future completes
@@ -196,12 +204,11 @@ where
 ///
 /// /// Awaitable non-send sleep function
 /// #[pyfunction]
-/// fn sleep_for(py: Python, secs: u64) -> PyResult<PyObject> {
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
 ///     // Rc is non-send so it cannot be passed into pyo3_asyncio::async_std::into_coroutine
 ///     let secs = Rc::new(secs);
-///
 ///     Ok(pyo3_asyncio::async_std::local_future_into_py_with_loop(
-///         pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py),
+///         pyo3_asyncio::async_std::current_event_loop(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
 ///             Python::with_gil(|py| Ok(py.None()))
@@ -214,10 +221,7 @@ where
 /// async fn main() -> PyResult<()> {
 ///     Python::with_gil(|py| {
 ///         let py_future = sleep_for(py, 1)?;
-///         pyo3_asyncio::into_future_with_loop(
-///             pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py),
-///             py_future.as_ref(py)
-///         )
+///         pyo3_asyncio::async_std::into_future(py_future)
 ///     })?
 ///     .await?;
 ///
@@ -231,4 +235,101 @@ where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     generic::local_future_into_py_with_loop::<AsyncStdRuntime, _>(event_loop, fut)
+}
+
+/// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::{rc::Rc, time::Duration};
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable non-send sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
+///     // Rc is non-send so it cannot be passed into pyo3_asyncio::async_std::into_coroutine
+///     let secs = Rc::new(secs);
+///     pyo3_asyncio::async_std::local_future_into_py(py, async move {
+///         async_std::task::sleep(Duration::from_secs(*secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///     })
+/// }
+///
+/// # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
+/// #[pyo3_asyncio::async_std::main]
+/// async fn main() -> PyResult<()> {
+///     Python::with_gil(|py| {
+///         let py_future = sleep_for(py, 1)?;
+///         pyo3_asyncio::async_std::into_future(py_future)
+///     })?
+///     .await?;
+///
+///     Ok(())
+/// }
+/// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
+/// # fn main() {}
+/// ```
+pub fn local_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + 'static,
+{
+    generic::local_future_into_py::<AsyncStdRuntime, _>(py, fut)
+}
+
+/// Convert a Python `awaitable` into a Rust Future
+///
+/// This function converts the `awaitable` into a Python Task using `run_coroutine_threadsafe`. A
+/// completion handler sends the result of this Task through a
+/// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
+/// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
+///
+/// # Arguments
+/// * `awaitable` - The Python `awaitable` to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// const PYTHON_CODE: &'static str = r#"
+/// import asyncio
+///
+/// async def py_sleep(duration):
+///     await asyncio.sleep(duration)
+/// "#;
+///
+/// async fn py_sleep(seconds: f32) -> PyResult<()> {
+///     let test_mod = Python::with_gil(|py| -> PyResult<PyObject> {
+///         Ok(
+///             PyModule::from_code(
+///                 py,
+///                 PYTHON_CODE,
+///                 "test_into_future/test_mod.py",
+///                 "test_mod"
+///             )?
+///             .into()
+///         )
+///     })?;
+///
+///     Python::with_gil(|py| {
+///         pyo3_asyncio::async_std::into_future(
+///             test_mod
+///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
+///                 .as_ref(py),
+///         )
+///     })?
+///     .await?;
+///     Ok(())    
+/// }
+/// ```
+pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
+    into_future_with_loop(current_event_loop(awaitable.py())?, awaitable)
 }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -134,7 +134,7 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
 /// [`run_forever`](`crate::run_forever`)
 ///
 /// # Arguments
-/// * `py` - The current PyO3 GIL guard
+/// * `event_loop` - The Python event loop that should run the future
 /// * `fut` - The future to drive to completion
 ///
 /// # Examples
@@ -148,7 +148,8 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
 /// #
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
-/// pyo3_asyncio::async_std::run_until_complete(py, async move {
+/// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
+/// pyo3_asyncio::async_std::run_until_complete(event_loop, async move {
 ///     async_std::task::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
 /// })?;
@@ -160,11 +161,11 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
 /// # .unwrap();
 /// # });
 /// ```
-pub fn run_until_complete<F>(py: Python, fut: F) -> PyResult<()>
+pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    generic::run_until_complete::<AsyncStdRuntime, _>(py, fut)
+    generic::run_until_complete::<AsyncStdRuntime, _>(event_loop, fut)
 }
 
 /// Run the event loop until the given Future completes

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -158,6 +158,39 @@ where
     generic::run_until_complete::<AsyncStdRuntime, _>(py, fut)
 }
 
+/// Run the event loop until the given Future completes
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The future to drive to completion
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// #
+/// # use pyo3::prelude::*;
+/// #
+/// fn main() {
+///     Python::with_gil(|py| {
+///         pyo3_asyncio::async_std::run(py, async move {
+///             async_std::task::sleep(Duration::from_secs(1)).await;
+///             Ok(())
+///         })
+///         .map_err(|e| {
+///             e.print_and_set_sys_last_vars(py);  
+///         })
+///         .unwrap();
+///     })
+/// }
+/// ```
+pub fn run<F>(py: Python, fut: F) -> PyResult<()>
+where
+    F: Future<Output = PyResult<()>> + Send + 'static,
+{
+    generic::run::<AsyncStdRuntime, F>(py, fut)
+}
+
 /// Convert a Rust Future into a Python awaitable
 ///
 /// # Arguments

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -215,6 +215,11 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.14.0",
+    note = "Use the pyo3_asyncio::async_std::future_into_py instead"
+)]
+#[allow(deprecated)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -195,13 +195,13 @@ where
 ///     // Rc is non-send so it cannot be passed into pyo3_asyncio::async_std::into_coroutine
 ///     let secs = Rc::new(secs);
 ///
-///     pyo3_asyncio::async_std::local_future_into_py(
+///     Ok(pyo3_asyncio::async_std::local_future_into_py(
 ///         pyo3_asyncio::async_std::task_event_loop().unwrap().as_ref(py),
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
 ///             Python::with_gil(|py| Ok(py.None()))
 ///         }
-///     )
+///     )?.into())
 /// }
 ///
 /// # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
@@ -221,7 +221,7 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<F>(event_loop: &PyAny, fut: F) -> PyResult<PyObject>
+pub fn local_future_into_py<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -144,6 +144,8 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
 /// #
 /// # use pyo3::prelude::*;
 /// #
+/// # pyo3::prepare_freethreaded_python();
+/// #
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
 /// pyo3_asyncio::async_std::run_until_complete(py, async move {
@@ -179,6 +181,9 @@ where
 /// # use pyo3::prelude::*;
 /// #
 /// fn main() {
+///     // call this or use pyo3 0.14 "auto-initialize" feature
+///     pyo3::prepare_freethreaded_python();
+///
 ///     Python::with_gil(|py| {
 ///         pyo3_asyncio::async_std::run(py, async move {
 ///             async_std::task::sleep(Duration::from_secs(1)).await;

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -110,8 +110,8 @@ where
 }
 
 /// Get the current event loop from either Python or Rust async task local context
-pub fn current_event_loop(py: Python) -> PyResult<&PyAny> {
-    generic::current_event_loop::<AsyncStdRuntime>(py)
+pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
+    generic::get_current_loop::<AsyncStdRuntime>(py)
 }
 
 /// Get the task local event loop for the current async_std task
@@ -276,7 +276,7 @@ where
 ///     // Rc is non-send so it cannot be passed into pyo3_asyncio::async_std::into_coroutine
 ///     let secs = Rc::new(secs);
 ///     Ok(pyo3_asyncio::async_std::local_future_into_py_with_loop(
-///         pyo3_asyncio::async_std::current_event_loop(py)?,
+///         pyo3_asyncio::async_std::get_current_loop(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
 ///             Python::with_gil(|py| Ok(py.None()))
@@ -399,5 +399,5 @@ where
 /// }
 /// ```
 pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
-    into_future_with_loop(current_event_loop(awaitable.py())?, awaitable)
+    into_future_with_loop(get_current_loop(awaitable.py())?, awaitable)
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,9 @@
+// FIXME - is there a way to document custom PyO3 exceptions?
+#[allow(missing_docs)]
+mod exceptions {
+    use pyo3::{create_exception, exceptions::PyException};
+
+    create_exception!(pyo3_asyncio, RustPanic, PyException);
+}
+
+pub use exceptions::RustPanic;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -2,7 +2,10 @@ use std::{future::Future, pin::Pin};
 
 use pyo3::prelude::*;
 
-use crate::{call_soon_threadsafe, create_future, dump_err, err::RustPanic, get_event_loop};
+use crate::{
+    call_soon_threadsafe, create_future, dump_err, err::RustPanic, get_cached_event_loop,
+    get_event_loop,
+};
 
 /// Generic utilities for a JoinError
 pub trait JoinError {
@@ -552,7 +555,7 @@ where
     R: Runtime,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    Ok(future_into_py::<R, F>(py, fut)?.into())
+    Ok(future_into_py_with_loop::<R, F>(get_cached_event_loop(py), fut)?.into())
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -363,7 +363,7 @@ where
 ///
 /// /// Awaitable sleep function
 /// #[pyfunction]
-/// fn sleep_for(py: Python, secs: u64) -> PyResult<PyObject> {
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
 ///     pyo3_asyncio::generic::local_future_into_py::<MyCustomRuntime, _>(
 ///         pyo3_asyncio::get_event_loop(py)?,
 ///         async move {
@@ -373,13 +373,13 @@ where
 ///     )
 /// }
 /// ```
-pub fn local_future_into_py<R, F>(event_loop: &PyAny, fut: F) -> PyResult<PyObject>
+pub fn local_future_into_py<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     R: SpawnLocalExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let future_rx = PyObject::from(create_future(event_loop)?);
-    let future_tx1 = future_rx.clone();
+    let future_rx = create_future(event_loop)?;
+    let future_tx1 = PyObject::from(future_rx);
     let future_tx2 = future_tx1.clone();
 
     let event_loop = PyObject::from(event_loop);

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -660,7 +660,7 @@ where
 /// ```
 #[deprecated(
     since = "0.14.0",
-    note = "Use the pyo3_asyncio::generic::future_into_py instead"
+    note = "Use the pyo3_asyncio::generic::future_into_py instead\n\t\t(see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
 )]
 #[allow(deprecated)]
 pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -2,6 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use pyo3::prelude::*;
 
+#[allow(deprecated)]
 use crate::{
     call_soon_threadsafe, create_future, dump_err, err::RustPanic, get_cached_event_loop,
     get_event_loop,
@@ -238,11 +239,15 @@ where
         "run_until_complete",
         (event_loop.call_method0("shutdown_asyncgens")?,),
     )?;
+
     // how to do this prior to 3.9?
-    // event_loop.call_method1(
-    //     "run_until_complete",
-    //     (event_loop.call_method0("shutdown_default_executor")?,),
-    // )?;
+    if event_loop.hasattr("shutdown_default_executor")? {
+        event_loop.call_method1(
+            "run_until_complete",
+            (event_loop.call_method0("shutdown_default_executor")?,),
+        )?;
+    }
+
     event_loop.call_method0("close")?;
 
     result?;
@@ -550,6 +555,11 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.14.0",
+    note = "Use the pyo3_asyncio::generic::future_into_py instead"
+)]
+#[allow(deprecated)]
 pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     R: Runtime,

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -4,8 +4,8 @@ use pyo3::prelude::*;
 
 #[allow(deprecated)]
 use crate::{
-    call_soon_threadsafe, close, create_future, dump_err, err::RustPanic, get_event_loop,
-    get_running_loop,
+    asyncio_get_event_loop, call_soon_threadsafe, close, create_future, dump_err, err::RustPanic,
+    get_event_loop, get_running_loop,
 };
 
 /// Generic utilities for a JoinError
@@ -141,7 +141,7 @@ where
     R: Runtime,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let event_loop = get_running_loop(py)?;
+    let event_loop = asyncio_get_event_loop(py)?;
 
     let coro = future_into_py_with_loop::<R, _>(event_loop, async move {
         fut.await?;
@@ -231,7 +231,7 @@ where
     R: Runtime,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let event_loop = get_running_loop(py)?;
+    let event_loop = asyncio_get_event_loop(py)?;
 
     let result = run_until_complete::<R, F>(py, fut);
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,8 +1,8 @@
-use std::future::Future;
+use std::{future::Future, pin::Pin};
 
 use pyo3::{exceptions::PyException, prelude::*};
 
-use crate::{dump_err, get_event_loop, CALL_SOON, CREATE_FUTURE, EXPECT_INIT};
+use crate::{call_soon_threadsafe, create_future, dump_err, get_event_loop};
 
 /// Generic utilities for a JoinError
 pub trait JoinError {
@@ -17,6 +17,13 @@ pub trait Runtime {
     /// A future that completes with the result of the spawned task
     type JoinHandle: Future<Output = Result<(), Self::JoinError>> + Send;
 
+    /// Set the task local event loop for the given future
+    fn scope<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+    where
+        F: Future<Output = R> + Send + 'static;
+    /// Get the task local event loop for the current task
+    fn get_task_event_loop() -> Option<PyObject>;
+
     /// Spawn a future onto this runtime's event loop
     fn spawn<F>(fut: F) -> Self::JoinHandle
     where
@@ -25,6 +32,11 @@ pub trait Runtime {
 
 /// Extension trait for async/await runtimes that support spawning local tasks
 pub trait SpawnLocalExt: Runtime {
+    /// Set the task local event loop for the given !Send future
+    fn scope_local<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+    where
+        F: Future<Output = R> + 'static;
+
     /// Spawn a !Send future onto this runtime's event loop
     fn spawn_local<F>(fut: F) -> Self::JoinHandle
     where
@@ -70,6 +82,16 @@ pub trait SpawnLocalExt: Runtime {
 /// # impl Runtime for MyCustomRuntime {
 /// #     type JoinError = MyCustomJoinError;
 /// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop() -> Option<PyObject> {
+/// #         unreachable!()
+/// #     }
 /// #
 /// #     fn spawn<F>(fut: F) -> Self::JoinHandle
 /// #     where
@@ -103,31 +125,27 @@ where
     R: Runtime,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let coro = into_coroutine::<R, _>(py, async move {
+    let event_loop = get_event_loop(py)?;
+
+    let coro = into_coroutine::<R, _>(event_loop, async move {
         fut.await?;
         Ok(Python::with_gil(|py| py.None()))
     })?;
 
-    get_event_loop(py).call_method1("run_until_complete", (coro,))?;
+    event_loop.call_method1("run_until_complete", (coro,))?;
 
     Ok(())
 }
 
-fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+fn set_result(event_loop: &PyAny, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
     match result {
         Ok(val) => {
             let set_result = future.getattr("set_result")?;
-            CALL_SOON
-                .get()
-                .expect(EXPECT_INIT)
-                .call1(py, (set_result, val))?;
+            call_soon_threadsafe(event_loop, (set_result, val))?;
         }
         Err(err) => {
             let set_exception = future.getattr("set_exception")?;
-            CALL_SOON
-                .get()
-                .expect(EXPECT_INIT)
-                .call1(py, (set_exception, err))?;
+            call_soon_threadsafe(event_loop, (set_exception, err))?;
         }
     }
 
@@ -176,6 +194,16 @@ fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResul
 /// # impl Runtime for MyCustomRuntime {
 /// #     type JoinError = MyCustomJoinError;
 /// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop() -> Option<PyObject> {
+/// #         unreachable!()
+/// #     }
 /// #
 /// #     fn spawn<F>(fut: F) -> Self::JoinHandle
 /// #     where
@@ -194,27 +222,34 @@ fn set_result(py: Python, future: &PyAny, result: PyResult<PyObject>) -> PyResul
 /// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
 ///     let secs = secs.extract()?;
 ///
-///     pyo3_asyncio::generic::into_coroutine::<MyCustomRuntime, _>(py, async move {
-///         MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
-///    })
+///     pyo3_asyncio::generic::into_coroutine::<MyCustomRuntime, _>(
+///         pyo3_asyncio::get_event_loop(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
 /// }
 /// ```
-pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
+pub fn into_coroutine<R, F>(event_loop: &PyAny, fut: F) -> PyResult<PyObject>
 where
     R: Runtime,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).call0(py)?;
+    let future_rx: PyObject = create_future(event_loop)?.into();
     let future_tx1 = future_rx.clone();
     let future_tx2 = future_rx.clone();
 
+    let event_loop = PyObject::from(event_loop);
+
     R::spawn(async move {
+        let event_loop2 = event_loop.clone();
+
         if let Err(e) = R::spawn(async move {
-            let result = fut.await;
+            let result = R::scope(event_loop2.clone(), fut).await;
 
             Python::with_gil(move |py| {
-                if set_result(py, future_tx1.as_ref(py), result)
+                if set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
                     .map_err(dump_err(py))
                     .is_err()
                 {
@@ -228,7 +263,7 @@ where
             if e.is_panic() {
                 Python::with_gil(move |py| {
                     if set_result(
-                        py,
+                        event_loop.as_ref(py),
                         future_tx2.as_ref(py),
                         Err(PyException::new_err("rust future panicked")),
                     )
@@ -287,6 +322,16 @@ where
 /// # impl Runtime for MyCustomRuntime {
 /// #     type JoinError = MyCustomJoinError;
 /// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop() -> Option<PyObject> {
+/// #         unreachable!()
+/// #     }
 /// #
 /// #     fn spawn<F>(fut: F) -> Self::JoinHandle
 /// #     where
@@ -297,6 +342,13 @@ where
 /// # }
 /// #
 /// # impl SpawnLocalExt for MyCustomRuntime {
+/// #     fn scope_local<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+/// #     where
+/// #         F: Future<Output = R> + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #    
 /// #     fn spawn_local<F>(fut: F) -> Self::JoinHandle
 /// #     where
 /// #         F: Future<Output = ()> + 'static
@@ -311,32 +363,38 @@ where
 ///
 /// /// Awaitable sleep function
 /// #[pyfunction]
-/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
-///     pyo3_asyncio::generic::local_future_into_py::<MyCustomRuntime, _>(py, async move {
-///         MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
-///    })
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<PyObject> {
+///     pyo3_asyncio::generic::local_future_into_py::<MyCustomRuntime, _>(
+///         pyo3_asyncio::get_event_loop(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
 /// }
 /// ```
-pub fn local_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py<R, F>(event_loop: &PyAny, fut: F) -> PyResult<PyObject>
 where
     R: SpawnLocalExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let future_rx = CREATE_FUTURE.get().expect(EXPECT_INIT).as_ref(py).call0()?;
-    let future_tx1 = PyObject::from(future_rx);
+    let future_rx = PyObject::from(create_future(event_loop)?);
+    let future_tx1 = future_rx.clone();
     let future_tx2 = future_tx1.clone();
 
+    let event_loop = PyObject::from(event_loop);
+
     R::spawn_local(async move {
+        let event_loop2 = event_loop.clone();
+
         if let Err(e) = R::spawn_local(async move {
-            let result = fut.await;
+            let result = R::scope_local(event_loop2.clone(), fut).await;
 
             Python::with_gil(move |py| {
-                if set_result(py, future_tx1.as_ref(py), result)
+                if set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
                     .map_err(dump_err(py))
                     .is_err()
                 {
-
                     // Cancelled
                 }
             });
@@ -346,7 +404,7 @@ where
             if e.is_panic() {
                 Python::with_gil(move |py| {
                     if set_result(
-                        py,
+                        event_loop.as_ref(py),
                         future_tx2.as_ref(py),
                         Err(PyException::new_err("rust future panicked")),
                     )

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,8 +1,8 @@
 use std::{future::Future, pin::Pin};
 
-use pyo3::{exceptions::PyException, prelude::*};
+use pyo3::prelude::*;
 
-use crate::{call_soon_threadsafe, create_future, dump_err, get_event_loop};
+use crate::{call_soon_threadsafe, create_future, dump_err, err::RustPanic, get_event_loop};
 
 /// Generic utilities for a JoinError
 pub trait JoinError {
@@ -265,7 +265,7 @@ where
                     if set_result(
                         event_loop.as_ref(py),
                         future_tx2.as_ref(py),
-                        Err(PyException::new_err("rust future panicked")),
+                        Err(RustPanic::new_err("rust future panicked")),
                     )
                     .map_err(dump_err(py))
                     .is_err()
@@ -406,7 +406,7 @@ where
                     if set_result(
                         event_loop.as_ref(py),
                         future_tx2.as_ref(py),
-                        Err(PyException::new_err("rust future panicked")),
+                        Err(RustPanic::new_err("Rust future panicked")),
                     )
                     .map_err(dump_err(py))
                     .is_err()

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -364,7 +364,7 @@ where
 /// /// Awaitable sleep function
 /// #[pyfunction]
 /// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
-///     pyo3_asyncio::generic::local_future_into_py::<MyCustomRuntime, _>(
+///     pyo3_asyncio::generic::local_future_into_py_with_loop::<MyCustomRuntime, _>(
 ///         pyo3_asyncio::get_event_loop(py)?,
 ///         async move {
 ///             MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
@@ -373,7 +373,7 @@ where
 ///     )
 /// }
 /// ```
-pub fn local_future_into_py<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     R: SpawnLocalExt,
     F: Future<Output = PyResult<PyObject>> + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ fn ensure_future<'p>(py: Python<'p>, awaitable: &'p PyAny) -> PyResult<&'p PyAny
         .call1((awaitable,))
 }
 
-fn create_future<'p>(event_loop: &'p PyAny) -> PyResult<&'p PyAny> {
+fn create_future(event_loop: &PyAny) -> PyResult<&PyAny> {
     event_loop.call_method0("create_future")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,17 +90,14 @@
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>testing</code></span> Utilities for writing PyO3 Asyncio tests
 #[cfg(feature = "testing")]
-#[doc(inline)]
 pub mod testing;
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>async-std-runtime</code></span> PyO3 Asyncio functions specific to the async-std runtime
 #[cfg(feature = "async-std")]
-#[doc(inline)]
 pub mod async_std;
 
 /// <span class="module-item stab portability" style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>tokio-runtime</code></span> PyO3 Asyncio functions specific to the tokio runtime
 #[cfg(feature = "tokio-runtime")]
-#[doc(inline)]
 pub mod tokio;
 
 /// Errors and exceptions related to PyO3 Asyncio

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,202 @@
 //! means that Cargo's default test harness will no longer work since it doesn't provide a method of
 //! overriding the main function to add our event loop initialization and finalization.
 //!
+//! ## Event Loop References
+//!
+//! One problem that arises when interacting with Python's asyncio library is that the functions we use to get a reference to the Python event loop can only be called in certain contexts. Since PyO3 Asyncio needs to interact with Python's event loop during conversions, the context of these conversions can matter a lot.
+//!
+//! > The core conversions we've mentioned so far in this guide should insulate you from these concerns in most cases, but in the event that they don't, this section should provide you with the information you need to solve these problems.
+//!
+//! ### The Main Dilemma
+//!
+//! Python programs can have many independent event loop instances throughout the lifetime of the application (`asyncio.run` for example creates its own event loop each time it's called for instance), and they can even run concurrent with other event loops. For this reason, the most correct method of obtaining a reference to the Python event loop is via `asyncio.get_running_loop`.
+//!
+//! `asyncio.get_running_loop` returns the event loop associated with the current OS thread. It can be used inside Python coroutines to spawn concurrent tasks, interact with timers, or in our case signal between Rust and Python. This is all well and good when we are operating on a Python thread, but since Rust threads are not associated with a Python event loop, `asyncio.get_running_loop` will fail when called on a Rust runtime.
+//!
+//! ### The Solution
+//!
+//! A really straightforward way of dealing with this problem is to pass a reference to the associated Python event loop for every conversion. That's why in `v0.14`, we introduced a new set of conversion functions that do just that:
+//!
+//! - `pyo3_asyncio::into_future_with_loop` - Convert a Python awaitable into a Rust future with the given asyncio event loop.
+//! - `pyo3_asyncio::<runtime>::future_into_py_with_loop` - Convert a Rust future into a Python awaitable with the given asyncio event loop.
+//! - `pyo3_asyncio::<runtime>::local_future_into_py_with_loop` - Convert a `!Send` Rust future into a Python awaitable with the given asyncio event loop.
+//!
+//! One clear disadvantage to this approach (aside from the verbose naming) is that the Rust application has to explicitly track its references to the Python event loop. In native libraries, we can't make any assumptions about the underlying event loop, so the only reliable way to make sure our conversions work properly is to store a reference to the current event loop at the callsite to use later on.
+//!
+//! ```rust
+//! use pyo3::prelude::*;
+//!
+//! #[pyfunction]
+//! fn sleep(py: Python) -> PyResult<&PyAny> {
+//!     let current_loop = pyo3_asyncio::get_running_loop(py)?;
+//!     let loop_ref = PyObject::from(current_loop);
+//!
+//!     // Convert the async move { } block to a Python awaitable
+//!     pyo3_asyncio::tokio::future_into_py_with_loop(current_loop, async move {
+//!         let py_sleep = Python::with_gil(|py| {
+//!             // Sometimes we need to call other async Python functions within
+//!             // this future. In order for this to work, we need to track the
+//!             // event loop from earlier.
+//!             pyo3_asyncio::into_future_with_loop(
+//!                 loop_ref.as_ref(py),
+//!                 py.import("asyncio")?.call_method1("sleep", (1,))?
+//!             )
+//!         })?;
+//!
+//!         py_sleep.await?;
+//!
+//!         Ok(Python::with_gil(|py| py.None()))
+//!     })
+//! }
+//!
+//! #[pymodule]
+//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! > A naive solution to this tracking problem would be to cache a global reference to the asyncio event loop that all PyO3 Asyncio conversions can use. In fact this is what we did in PyO3 Asyncio `v0.13`. This works well for applications, but it soon became clear that this is not so ideal for libraries. Libraries usually have no direct control over how the event loop is managed, they're just expected to work with any event loop at any point in the application. This problem is compounded further when multiple event loops are used in the application since the global reference will only point to one.
+//!
+//! Another disadvantage to this explicit approach that is less obvious is that we can no longer call our `#[pyfunction] fn sleep` on a Rust runtime since `asyncio.get_running_loop` only works on Python threads! It's clear that we need a slightly more flexible approach.
+//!
+//! In order to detect the Python event loop at the callsite, we need something like `asyncio.get_running_loop` that works for _both Python and Rust_. In Python, `asyncio.get_running_loop` uses thread-local data to retrieve the event loop associated with the current thread. What we need in Rust is something that can retrieve the Python event loop associated with the current _task_.
+//!
+//! Enter `pyo3_asyncio::<runtime>::get_current_loop`. This function first checks task-local data for a Python event loop, then falls back on `asyncio.get_running_loop` if no task-local event loop is found. This way both bases are covered.
+//!
+//! Now, all we need is a way to store the event loop in task-local data. Since this is a runtime-specific feature, you can find the following functions in each runtime module:
+//!
+//! - `pyo3_asyncio::<runtime>::scope` - Store the event loop in task-local data when executing the given Future.
+//! - `pyo3_asyncio::<runtime>::scope_local` - Store the event loop in task-local data when executing the given `!Send` Future.
+//!
+//! With these new functions, we can make our previous example more correct:
+//!
+//! ```rust no_run
+//! use pyo3::prelude::*;
+//!
+//! #[pyfunction]
+//! fn sleep(py: Python) -> PyResult<&PyAny> {
+//!     // get the current event loop through task-local data
+//!     // OR `asyncio.get_running_loop`
+//!     let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
+//!
+//!     pyo3_asyncio::tokio::future_into_py_with_loop(
+//!         current_loop,
+//!         // Store the current loop in task-local data
+//!         pyo3_asyncio::tokio::scope(current_loop.into(), async move {
+//!             let py_sleep = Python::with_gil(|py| {
+//!                 pyo3_asyncio::into_future_with_loop(
+//!                     // Now we can get the current loop through task-local data
+//!                     pyo3_asyncio::tokio::get_current_loop(py)?,
+//!                     py.import("asyncio")?.call_method1("sleep", (1,))?
+//!                 )
+//!             })?;
+//!
+//!             py_sleep.await?;
+//!
+//!             Ok(Python::with_gil(|py| py.None()))
+//!         })
+//!     )
+//! }
+//!
+//! #[pyfunction]
+//! fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
+//!     // get the current event loop through task-local data
+//!     // OR `asyncio.get_running_loop`
+//!     let current_loop = pyo3_asyncio::tokio::get_current_loop(py)?;
+//!
+//!     pyo3_asyncio::tokio::future_into_py_with_loop(
+//!         current_loop,
+//!         // Store the current loop in task-local data
+//!         pyo3_asyncio::tokio::scope(current_loop.into(), async move {
+//!             let py_sleep = Python::with_gil(|py| {
+//!                 pyo3_asyncio::into_future_with_loop(
+//!                     pyo3_asyncio::tokio::get_current_loop(py)?,
+//!                     // We can also call sleep within a Rust task since the
+//!                     // event loop is stored in task local data
+//!                     sleep(py)?
+//!                 )
+//!             })?;
+//!
+//!             py_sleep.await?;
+//!
+//!             Ok(Python::with_gil(|py| py.None()))
+//!         })
+//!     )
+//! }
+//!
+//! #[pymodule]
+//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
+//!     m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Even though this is more correct, it's clearly not more ergonomic. That's why we introduced a new set of functions with this functionality baked in:
+//!
+//! - `pyo3_asyncio::<runtime>::into_future`
+//!   > Convert a Python awaitable into a Rust future (using `pyo3_asyncio::<runtime>::get_current_loop`)
+//! - `pyo3_asyncio::<runtime>::future_into_py`
+//!   > Convert a Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope` to set the task-local event loop for the given Rust future)
+//! - `pyo3_asyncio::<runtime>::local_future_into_py`
+//!   > Convert a `!Send` Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope_local` to set the task-local event loop for the given Rust future).
+//!
+//! __These are the functions that we recommend using__. With these functions, the previous example can be rewritten to be more compact:
+//!
+//! ```rust
+//! use pyo3::prelude::*;
+//!
+//! #[pyfunction]
+//! fn sleep(py: Python) -> PyResult<&PyAny> {
+//!     pyo3_asyncio::tokio::future_into_py(py, async move {
+//!         let py_sleep = Python::with_gil(|py| {
+//!             pyo3_asyncio::tokio::into_future(
+//!                 py.import("asyncio")?.call_method1("sleep", (1,))?
+//!             )
+//!         })?;
+//!
+//!         py_sleep.await?;
+//!
+//!         Ok(Python::with_gil(|py| py.None()))
+//!     })
+//! }
+//!
+//! #[pyfunction]
+//! fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
+//!     pyo3_asyncio::tokio::future_into_py(py, async move {
+//!         let py_sleep = Python::with_gil(|py| {
+//!             pyo3_asyncio::tokio::into_future(sleep(py)?)
+//!         })?;
+//!
+//!         py_sleep.await?;
+//!
+//!         Ok(Python::with_gil(|py| py.None()))
+//!     })
+//! }
+//!
+//! #[pymodule]
+//! fn my_mod(py: Python, m: &PyModule) -> PyResult<()> {
+//!     m.add_function(wrap_pyfunction!(sleep, m)?)?;
+//!     m.add_function(wrap_pyfunction!(wrap_sleep, m)?)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## A Note for `v0.13` Users
+//!
+//! Hey guys, I realize that these are pretty major changes for `v0.14`, and I apologize in advance for having to modify the public API so much. I hope
+//! the explanation above gives some much needed context and justification for all the breaking changes.
+//!
+//! Part of the reason why it's taken so long to push out a `v0.14` release is because I wanted to make sure we got this release right. There were a lot of issues with the `v0.13` release that I hadn't anticipated, and it's thanks to your feedback and patience that we've worked through these issues to get a more correct, more flexible version out there!
+//!
+//! This new release should address most the core issues that users have reported in the `v0.13` release, so I think we can expect more stability going forward.
+//!
+//! Also, a special thanks to [@ShadowJonathan](https://github.com/ShadowJonathan) for helping with the design and review
+//! of these changes!
+//!
+//! - [@awestlake87](https://github.com/awestlake87)
+//!
 //! ## Rust's Event Loop
 //!
 //! Currently only the async-std and Tokio runtimes are supported by this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,13 +263,13 @@ fn asyncio_get_event_loop(py: Python) -> PyResult<&PyAny> {
 
 /// Get a reference to the Python Event Loop from Rust
 ///
-/// Equivalent to `asyncio.get_running_loop()` in Python 3.7+
+/// Equivalent to `asyncio.get_running_loop()` in Python 3.7+.
 /// > For Python 3.6, this function falls back to `asyncio.get_event_loop()` which has slightly
 /// different behaviour. See the [`asyncio.get_event_loop`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop)
 /// docs to better understand the differences.
 pub fn get_running_loop(py: Python) -> PyResult<&PyAny> {
-    // Ideally should call get_running_loop, but calls get_event_loop for compatibility between
-    // versions.
+    // Ideally should call get_running_loop, but calls get_event_loop for compatibility when
+    // get_running_loop is not available.
     GET_RUNNING_LOOP
         .get_or_try_init(|| -> PyResult<PyObject> {
             let asyncio = asyncio(py)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ fn create_future(event_loop: &PyAny) -> PyResult<&PyAny> {
 /// ```
 #[deprecated(
     since = "0.14.0",
-    note = "Use the pyo3_asyncio::async_std::run or pyo3_asyncio::tokio::run instead"
+    note = "Use the pyo3_asyncio::async_std::run or pyo3_asyncio::tokio::run instead\n\t\t(see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
 )]
 #[allow(deprecated)]
 pub fn with_runtime<F, R>(py: Python, f: F) -> PyResult<R>
@@ -431,7 +431,10 @@ fn close(event_loop: &PyAny) -> PyResult<()> {
 /// - Must be called before any other pyo3-asyncio functions.
 /// - Calling `try_init` a second time returns `Ok(())` and does nothing.
 ///   > In future versions this may return an `Err`.
-#[deprecated(since = "0.14.0")]
+#[deprecated(
+    since = "0.14.0",
+    note = "see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details"
+)]
 pub fn try_init(py: Python) -> PyResult<()> {
     CACHED_EVENT_LOOP.get_or_try_init(|| -> PyResult<PyObject> {
         let event_loop = asyncio_get_event_loop(py)?;
@@ -483,7 +486,10 @@ pub fn get_running_loop(py: Python) -> PyResult<&PyAny> {
 }
 
 /// Get a reference to the Python event loop cached by `try_init` (0.13 behaviour)
-#[deprecated(since = "0.14.0")]
+#[deprecated(
+    since = "0.14.0",
+    note = "see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details"
+)]
 pub fn get_event_loop(py: Python) -> &PyAny {
     CACHED_EVENT_LOOP.get().expect(EXPECT_INIT).as_ref(py)
 }
@@ -539,7 +545,10 @@ pub fn get_event_loop(py: Python) -> &PyAny {
 /// }
 /// # #[cfg(not(feature = "async-std-runtime"))]
 /// # fn main() {}
-#[deprecated(since = "0.14.0")]
+#[deprecated(
+    since = "0.14.0",
+    note = "see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details"
+)]
 #[allow(deprecated)]
 pub fn run_forever(py: Python) -> PyResult<()> {
     if let Err(e) = get_event_loop(py).call_method0("run_forever") {
@@ -554,7 +563,10 @@ pub fn run_forever(py: Python) -> PyResult<()> {
 }
 
 /// Shutdown the event loops and perform any necessary cleanup
-#[deprecated(since = "0.14.0")]
+#[deprecated(
+    since = "0.14.0",
+    note = "see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details"
+)]
 pub fn try_close(py: Python) -> PyResult<()> {
     if let Some(exec) = EXECUTOR.get() {
         // Shutdown the executor and wait until all threads are cleaned up
@@ -751,7 +763,7 @@ pub fn into_future_with_loop(
 /// ```
 #[deprecated(
     since = "0.14.0",
-    note = "Use pyo3_asyncio::async_std::into_future or pyo3_asyncio::tokio::into_future"
+    note = "Use pyo3_asyncio::async_std::into_future or pyo3_asyncio::tokio::into_future instead\n    (see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
 )]
 #[allow(deprecated)]
 pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ fn asyncio_get_event_loop(py: Python) -> PyResult<&PyAny> {
 pub fn get_running_loop(py: Python) -> PyResult<&PyAny> {
     // Ideally should call get_running_loop, but calls get_event_loop for compatibility between
     // versions.
-    asyncio(py)?.call_method0("get_running_loop")
+    asyncio(py)?.call_method0("get_event_loop")
 }
 
 /// Get a reference to the Python event loop cached by `try_init` (0.13 behaviour)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ fn call_soon_threadsafe(event_loop: &PyAny, args: impl IntoPy<Py<PyTuple>>) -> P
 ///     })?;
 ///
 ///     Python::with_gil(|py| {
-///         pyo3_asyncio::into_future(
+///         pyo3_asyncio::into_future_with_loop(
 ///             pyo3_asyncio::get_event_loop(py)?,
 ///             test_mod
 ///                 .call_method1(py, "py_sleep", (seconds.into_py(py),))?
@@ -418,7 +418,7 @@ fn call_soon_threadsafe(event_loop: &PyAny, args: impl IntoPy<Py<PyTuple>>) -> P
 ///     Ok(())    
 /// }
 /// ```
-pub fn into_future(
+pub fn into_future_with_loop(
     event_loop: &PyAny,
     awaitable: &PyAny,
 ) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub mod async_std;
 #[doc(inline)]
 pub mod tokio;
 
+/// Errors and exceptions related to PyO3 Asyncio
+pub mod err;
+
 /// Generic implementations of PyO3 Asyncio utilities that can be used for any Rust runtime
 pub mod generic;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,7 @@ fn call_soon_threadsafe(event_loop: &PyAny, args: impl IntoPy<Py<PyTuple>>) -> P
 /// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
 ///
 /// # Arguments
+/// * `event_loop` - The Python event loop that the awaitable should be attached to
 /// * `awaitable` - The Python `awaitable` to be converted
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,9 @@ fn create_future(event_loop: &PyAny) -> PyResult<&PyAny> {
 /// use pyo3::prelude::*;
 ///
 /// fn main() {
+///     // Call this function or use pyo3's "auto-initialize" feature
+///     pyo3::prepare_freethreaded_python();
+///
 ///     Python::with_gil(|py| {
 ///         pyo3_asyncio::with_runtime(py, || {
 ///             println!("PyO3 Asyncio Initialized!");
@@ -310,6 +313,9 @@ pub fn get_event_loop(py: Python) -> &PyAny {
 /// fn main() -> pyo3::PyResult<()> {
 ///     use std::time::Duration;
 ///     use pyo3::prelude::*;
+///     
+///     // call this or use pyo3 0.14 "auto-initialize" feature
+///     pyo3::prepare_freethreaded_python();
 ///
 ///     Python::with_gil(|py| {
 ///         pyo3_asyncio::with_runtime(py, || {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -155,7 +155,7 @@
 //! # ))]
 //! mod tests {
 //!     use pyo3::prelude::*;
-//!     
+//!
 //! #   #[cfg(feature = "async-std-runtime")]
 //!     #[pyo3_asyncio::async_std::test]
 //!     async fn test_async_std_async_test_compiles() -> PyResult<()> {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -95,7 +95,7 @@
 //!     }
 //!
 //!     #[pyo3_asyncio::async_std::test]
-//!     fn test_blocking_sleep(_event_loop: PyObject) -> PyResult<()> {
+//!     fn test_blocking_sleep() -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
 //!         Ok(())
 //!     }
@@ -125,7 +125,7 @@
 //!     }
 //!
 //!     #[pyo3_asyncio::tokio::test]
-//!     fn test_blocking_sleep(_event_loop: PyObject) -> PyResult<()> {
+//!     fn test_blocking_sleep() -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
 //!         Ok(())
 //!     }
@@ -163,7 +163,7 @@
 //!     }
 //! #   #[cfg(feature = "async-std-runtime")]
 //!     #[pyo3_asyncio::async_std::test]
-//!     fn test_async_std_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
+//!     fn test_async_std_sync_test_compiles() -> PyResult<()> {
 //!         Ok(())
 //!     }
 //!
@@ -174,7 +174,7 @@
 //!     }
 //! #   #[cfg(feature = "tokio-runtime")]
 //!     #[pyo3_asyncio::tokio::test]
-//!     fn test_tokio_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
+//!     fn test_tokio_sync_test_compiles() -> PyResult<()> {
 //!         Ok(())
 //!     }
 //! }
@@ -341,7 +341,7 @@ mod tests {
     }
     #[cfg(feature = "async-std-runtime")]
     #[pyo3_asyncio::async_std::test]
-    fn test_async_std_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
+    fn test_async_std_sync_test_compiles() -> PyResult<()> {
         Ok(())
     }
 
@@ -352,7 +352,7 @@ mod tests {
     }
     #[cfg(feature = "tokio-runtime")]
     #[pyo3_asyncio::tokio::test]
-    fn test_tokio_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
+    fn test_tokio_sync_test_compiles() -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -95,7 +95,7 @@
 //!     }
 //!
 //!     #[pyo3_asyncio::async_std::test]
-//!     fn test_blocking_sleep() -> PyResult<()> {
+//!     fn test_blocking_sleep(_event_loop: PyObject) -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
 //!         Ok(())
 //!     }
@@ -125,7 +125,7 @@
 //!     }
 //!
 //!     #[pyo3_asyncio::tokio::test]
-//!     fn test_blocking_sleep() -> PyResult<()> {
+//!     fn test_blocking_sleep(_event_loop: PyObject) -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
 //!         Ok(())
 //!     }
@@ -163,7 +163,7 @@
 //!     }
 //! #   #[cfg(feature = "async-std-runtime")]
 //!     #[pyo3_asyncio::async_std::test]
-//!     fn test_async_std_sync_test_compiles() -> PyResult<()> {
+//!     fn test_async_std_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
 //!         Ok(())
 //!     }
 //!
@@ -174,7 +174,7 @@
 //!     }
 //! #   #[cfg(feature = "tokio-runtime")]
 //!     #[pyo3_asyncio::tokio::test]
-//!     fn test_tokio_sync_test_compiles() -> PyResult<()> {
+//!     fn test_tokio_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
 //!         Ok(())
 //!     }
 //! }
@@ -341,7 +341,7 @@ mod tests {
     }
     #[cfg(feature = "async-std-runtime")]
     #[pyo3_asyncio::async_std::test]
-    fn test_async_std_sync_test_compiles() -> PyResult<()> {
+    fn test_async_std_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
         Ok(())
     }
 
@@ -352,7 +352,7 @@ mod tests {
     }
     #[cfg(feature = "tokio-runtime")]
     #[pyo3_asyncio::tokio::test]
-    fn test_tokio_sync_test_compiles() -> PyResult<()> {
+    fn test_tokio_sync_test_compiles(_event_loop: PyObject) -> PyResult<()> {
         Ok(())
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -18,45 +18,34 @@
 //! overriding the default test harness can be quite different from what you're used to doing for
 //! integration tests, so these next sections will walk you through this process.
 //!
-//! ### Main Test File
+//! ## Main Test File
 //! First, we need to create the test's main file. Although these tests are considered integration
 //! tests, we cannot put them in the `tests` directory since that is a special directory owned by
-//! Cargo. Instead, we put our tests in a `pytests` directory, although the name `pytests` is just
-//! a convention.
+//! Cargo. Instead, we put our tests in a `pytests` directory.
 //!
-//! We'll also want to provide the test's main function. Most of the functionality that the test
-//! harness needs is packed in this module's [`main`](crate::testing::main) function. It will parse
-//! the test's CLI arguments, collect and pass the functions marked with
-//! [`#[pyo3_asyncio::async_std::test]`](crate::async_std::test) or
-//! [`#[pyo3_asyncio::tokio::test]`](crate::tokio::test) and pass them into the test harness for
-//! running and filtering.
+//! > The name `pytests` is just a convention. You can name this folder anything you want in your own
+//! > projects.
+//!
+//! We'll also want to provide the test's main function. Most of the functionality that the test harness needs is packed in the [`pyo3_asyncio::testing::main`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/testing/fn.main.html) function. This function will parse the test's CLI arguments, collect and pass the functions marked with [`#[pyo3_asyncio::async_std::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) or [`#[pyo3_asyncio::tokio::test]`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) and pass them into the test harness for running and filtering.
 //!
 //! `pytests/test_example.rs` for the `tokio` runtime:
-//! ```
-//! # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
+//! ```rust
 //! #[pyo3_asyncio::tokio::main]
 //! async fn main() -> pyo3::PyResult<()> {
 //!     pyo3_asyncio::testing::main().await
 //! }
-//! #
-//! # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
-//! # fn main() {}
 //! ```
 //!
 //! `pytests/test_example.rs` for the `async-std` runtime:
-//! ```
-//! # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
+//! ```rust
 //! #[pyo3_asyncio::async_std::main]
 //! async fn main() -> pyo3::PyResult<()> {
 //!     pyo3_asyncio::testing::main().await
 //! }
-//! #
-//! # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
-//! # fn main() {}
 //! ```
 //!
-//! ### Cargo Configuration
-//! Next, we need to add our test file to the Cargo manifest. Add the following section to your
+//! ## Cargo Configuration
+//! Next, we need to add our test file to the Cargo manifest by adding the following section to the
 //! `Cargo.toml`
 //!
 //! ```toml
@@ -66,34 +55,33 @@
 //! harness = false
 //! ```
 //!
-//! Also, add the `testing` and `attributes` features to `pyo3-asyncio` and select your preferred
-//! runtime:
+//! Also add the `testing` and `attributes` features to the `pyo3-asyncio` dependency and select your preferred runtime:
 //!
 //! ```toml
-//! [dependencies]
 //! pyo3-asyncio = { version = "0.13", features = ["testing", "attributes", "async-std-runtime"] }
 //! ```
 //!
-//! At this point you should be able to run the test via `cargo test`
+//! At this point, you should be able to run the test via `cargo test`
 //!
 //! ### Adding Tests to the PyO3 Asyncio Test Harness
 //!
 //! We can add tests anywhere in the test crate with the runtime's corresponding `#[test]` attribute:
 //!
-//! For `async-std` use the [`pyo3_asyncio::async_std::test`](crate::async_std::test) attribute:
-//! ```
-//! # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
+//! For `async-std` use the [`pyo3_asyncio::async_std::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/async_std/attr.test.html) attribute:
+//! ```rust
 //! mod tests {
 //!     use std::{time::Duration, thread};
 //!
 //!     use pyo3::prelude::*;
 //!
+//!     // tests can be async
 //!     #[pyo3_asyncio::async_std::test]
 //!     async fn test_async_sleep() -> PyResult<()> {
 //!         async_std::task::sleep(Duration::from_secs(1)).await;
 //!         Ok(())
 //!     }
 //!
+//!     // they can also be synchronous
 //!     #[pyo3_asyncio::async_std::test]
 //!     fn test_blocking_sleep() -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
@@ -101,29 +89,27 @@
 //!     }
 //! }
 //!
-//! # #[cfg(all(feature = "async-std-runtime", feature = "attributes"))]
 //! #[pyo3_asyncio::async_std::main]
 //! async fn main() -> pyo3::PyResult<()> {
 //!     pyo3_asyncio::testing::main().await
 //! }
-//! # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
-//! # fn main() {}
 //! ```
 //!
-//! For `tokio` use the [`pyo3_asyncio::tokio::test`](crate::tokio::test) attribute:
-//! ```
-//! # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
+//! For `tokio` use the [`pyo3_asyncio::tokio::test`](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/tokio/attr.test.html) attribute:
+//! ```rust
 //! mod tests {
 //!     use std::{time::Duration, thread};
 //!
 //!     use pyo3::prelude::*;
 //!
+//!     // tests can be async
 //!     #[pyo3_asyncio::tokio::test]
 //!     async fn test_async_sleep() -> PyResult<()> {
 //!         tokio::time::sleep(Duration::from_secs(1)).await;
 //!         Ok(())
 //!     }
 //!
+//!     // they can also be synchronous
 //!     #[pyo3_asyncio::tokio::test]
 //!     fn test_blocking_sleep() -> PyResult<()> {
 //!         thread::sleep(Duration::from_secs(1));
@@ -131,21 +117,18 @@
 //!     }
 //! }
 //!
-//! # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 //! #[pyo3_asyncio::tokio::main]
 //! async fn main() -> pyo3::PyResult<()> {
 //!     pyo3_asyncio::testing::main().await
 //! }
-//! # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
-//! # fn main() {}
 //! ```
 //!
-//! ### Lib Tests
+//! ## Lib Tests
 //!
 //! Unfortunately, as we mentioned at the beginning, these utilities will only run in integration
 //! tests and doc tests. Running lib tests are out of the question since we need control over the
-//! main function. You can however perform compilation checks for lib tests. This is unfortunately
-//! much more useful in doc tests than it is for lib tests, but the option is there if you want it.
+//! main function. You can however perform compilation checks for lib tests. This is much more
+//! useful in doc tests than it is for lib tests, but the option is there if you want it.
 //!
 //! `my-crate/src/lib.rs`
 //! ```

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -64,7 +64,10 @@ impl GenericRuntime for TokioRuntime {
     }
 
     fn get_task_event_loop(py: Python) -> Option<&PyAny> {
-        EVENT_LOOP.with(|c| c.get().map(|event_loop| event_loop.clone().into_ref(py)))
+        match EVENT_LOOP.try_with(|c| c.get().map(|event_loop| event_loop.clone().into_ref(py))) {
+            Ok(event_loop) => event_loop,
+            Err(_) => None,
+        }
     }
 
     fn spawn<F>(fut: F) -> Self::JoinHandle
@@ -260,21 +263,17 @@ where
 /// #[pyfunction]
 /// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
 ///     let secs = secs.extract()?;
-///
-///     pyo3_asyncio::tokio::into_coroutine(
-///         pyo3_asyncio::tokio::current_event_loop(py)?,
-///         async move {
-///             tokio::time::sleep(Duration::from_secs(secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
-///         }
-///     )
+///     pyo3_asyncio::tokio::into_coroutine(py, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///     })
 /// }
 /// ```
-pub fn into_coroutine<F>(event_loop: &PyAny, fut: F) -> PyResult<PyObject>
+pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    generic::into_coroutine::<TokioRuntime, _>(event_loop, fut)
+    generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -116,8 +116,8 @@ where
 }
 
 /// Get the current event loop from either Python or Rust async task local context
-pub fn current_event_loop(py: Python) -> PyResult<&PyAny> {
-    generic::current_event_loop::<TokioRuntime>(py)
+pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
+    generic::get_current_loop::<TokioRuntime>(py)
 }
 
 /// Get the task local event loop for the current tokio task
@@ -364,7 +364,7 @@ where
 ///     let secs = Rc::new(secs);
 ///
 ///     pyo3_asyncio::tokio::local_future_into_py_with_loop(
-///         pyo3_asyncio::tokio::current_event_loop(py)?,
+///         pyo3_asyncio::tokio::get_current_loop(py)?,
 ///         async move {
 ///             tokio::time::sleep(Duration::from_secs(*secs)).await;
 ///             Python::with_gil(|py| Ok(py.None()))
@@ -517,5 +517,5 @@ where
 /// }
 /// ```
 pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
-    into_future_with_loop(current_event_loop(awaitable.py())?, awaitable)
+    into_future_with_loop(get_current_loop(awaitable.py())?, awaitable)
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -204,7 +204,7 @@ pub fn init_current_thread_once() {
 /// [`crate::run_forever`]
 ///
 /// # Arguments
-/// * `py` - The current PyO3 GIL guard
+/// * `event_loop` - The Python event loop that should run the future
 /// * `fut` - The future to drive to completion
 ///
 /// # Examples
@@ -224,7 +224,8 @@ pub fn init_current_thread_once() {
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
 /// # pyo3_asyncio::tokio::init_current_thread();
-/// pyo3_asyncio::tokio::run_until_complete(py, async move {
+/// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
+/// pyo3_asyncio::tokio::run_until_complete(event_loop, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
 /// })?;
@@ -236,11 +237,11 @@ pub fn init_current_thread_once() {
 /// # .unwrap();
 /// # });
 /// ```
-pub fn run_until_complete<F>(py: Python, fut: F) -> PyResult<()>
+pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    generic::run_until_complete::<TokioRuntime, _>(py, fut)
+    generic::run_until_complete::<TokioRuntime, _>(event_loop, fut)
 }
 
 /// Run the event loop until the given Future completes

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -309,6 +309,36 @@ where
     generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
 
+/// Convert a Rust Future into a Python awaitable
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///     pyo3_asyncio::tokio::future_into_py(py, async move {
+///         tokio::time::sleep(Duration::from_secs(secs)).await;
+///         Python::with_gil(|py| Ok(py.None()))
+///     })
+/// }
+/// ```
+pub fn future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    generic::future_into_py::<TokioRuntime, _>(py, fut)
+}
+
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// # Arguments

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -302,6 +302,11 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.14.0",
+    note = "Use the pyo3_asyncio::tokio::future_into_py instead"
+)]
+#[allow(deprecated)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -243,7 +243,7 @@ where
 /// ```
 #[deprecated(
     since = "0.14.0",
-    note = "Use the pyo3_asyncio::tokio::future_into_py instead"
+    note = "Use pyo3_asyncio::tokio::future_into_py instead\n    (see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
 )]
 #[allow(deprecated)]
 pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,11 +1,13 @@
-use std::{future::Future, pin::Pin, thread};
+use std::{future::Future, pin::Pin, sync::Mutex};
 
 use ::tokio::{
     runtime::{Builder, Runtime},
     task,
 };
-use futures::future::pending;
-use once_cell::{sync::OnceCell, unsync::OnceCell as UnsyncOnceCell};
+use once_cell::{
+    sync::{Lazy, OnceCell},
+    unsync::OnceCell as UnsyncOnceCell,
+};
 use pyo3::prelude::*;
 
 use crate::generic::{self, Runtime as GenericRuntime, SpawnLocalExt};
@@ -30,9 +32,8 @@ pub use pyo3_asyncio_macros::tokio_main as main;
 #[cfg(all(feature = "attributes", feature = "testing"))]
 pub use pyo3_asyncio_macros::tokio_test as test;
 
+static TOKIO_BUILDER: Lazy<Mutex<Builder>> = Lazy::new(|| Mutex::new(multi_thread()));
 static TOKIO_RUNTIME: OnceCell<Runtime> = OnceCell::new();
-
-const EXPECT_TOKIO_INIT: &str = "Tokio runtime must be initialized";
 
 impl generic::JoinError for task::JoinError {
     fn is_panic(&self) -> bool {
@@ -121,79 +122,26 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
     generic::get_current_loop::<TokioRuntime>(py)
 }
 
-/// Initialize the Tokio Runtime with a custom build
-pub fn init(runtime: Runtime) {
-    TOKIO_RUNTIME
-        .set(runtime)
-        .expect("Tokio Runtime has already been initialized");
-}
-
-fn current_thread() -> Runtime {
-    Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("Couldn't build the current-thread Tokio runtime")
-}
-
-fn start_current_thread() {
-    thread::spawn(move || {
-        TOKIO_RUNTIME.get().unwrap().block_on(pending::<()>());
-    });
-}
-
-/// Initialize the Tokio Runtime with current-thread scheduler
-///
-/// # Panics
-/// This function will panic if called a second time. See [`init_current_thread_once`] if you want
-/// to avoid this panic.
-pub fn init_current_thread() {
-    init(current_thread());
-    start_current_thread();
+/// Initialize the Tokio runtime with a custom build
+pub fn init(builder: Builder) {
+    *TOKIO_BUILDER.lock().unwrap() = builder
 }
 
 /// Get a reference to the current tokio runtime
 pub fn get_runtime<'a>() -> &'a Runtime {
-    TOKIO_RUNTIME.get().expect(EXPECT_TOKIO_INIT)
-}
-
-fn multi_thread() -> Runtime {
-    Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Couldn't build the multi-thread Tokio runtime")
-}
-
-/// Initialize the Tokio Runtime with the multi-thread scheduler
-///
-/// # Panics
-/// This function will panic if called a second time. See [`init_multi_thread_once`] if you want to
-/// avoid this panic.
-pub fn init_multi_thread() {
-    init(multi_thread());
-}
-
-/// Ensure that the Tokio Runtime is initialized
-///
-/// If the runtime has not been initialized already, the multi-thread scheduler
-/// is used. Calling this function a second time is a no-op.
-pub fn init_multi_thread_once() {
-    TOKIO_RUNTIME.get_or_init(|| multi_thread());
-}
-
-/// Ensure that the Tokio Runtime is initialized
-///
-/// If the runtime has not been initialized already, the current-thread
-/// scheduler is used. Calling this function a second time is a no-op.
-pub fn init_current_thread_once() {
-    let mut initialized = false;
     TOKIO_RUNTIME.get_or_init(|| {
-        initialized = true;
-        current_thread()
-    });
+        TOKIO_BUILDER
+            .lock()
+            .unwrap()
+            .build()
+            .expect("Unable to build Tokio runtime")
+    })
+}
 
-    if initialized {
-        start_current_thread();
-    }
+fn multi_thread() -> Builder {
+    let mut builder = Builder::new_multi_thread();
+    builder.enable_all();
+    builder
 }
 
 /// Run the event loop until the given Future completes
@@ -213,17 +161,10 @@ pub fn init_current_thread_once() {
 /// # use std::time::Duration;
 /// #
 /// # use pyo3::prelude::*;
-/// # use tokio::runtime::{Builder, Runtime};
-/// #
-/// # let runtime = Builder::new_current_thread()
-/// #     .enable_all()
-/// #     .build()
-/// #     .expect("Couldn't build the runtime");
 /// #
 /// # pyo3::prepare_freethreaded_python();
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
-/// # pyo3_asyncio::tokio::init_current_thread();
 /// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_asyncio::tokio::run_until_complete(event_loop, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -93,6 +93,7 @@ impl SpawnLocalExt for TokioRuntime {
     }
 }
 
+/// Set the task local event loop for the given future
 pub async fn scope<F, R>(event_loop: PyObject, fut: F) -> R
 where
     F: Future<Output = R> + Send + 'static,
@@ -100,6 +101,7 @@ where
     TokioRuntime::scope(event_loop, fut).await
 }
 
+/// Set the task local event loop for the given !Send future
 pub async fn scope_local<F, R>(event_loop: PyObject, fut: F) -> R
 where
     F: Future<Output = R> + 'static,
@@ -284,7 +286,7 @@ where
 ///     let secs = Rc::new(secs);
 ///     let event_loop = pyo3_asyncio::tokio::task_event_loop().unwrap();
 ///
-///     Ok(pyo3_asyncio::tokio::local_future_into_py(event_loop.as_ref(py), async move {
+///     Ok(pyo3_asyncio::tokio::local_future_into_py_with_loop(event_loop.as_ref(py), async move {
 ///         tokio::time::sleep(Duration::from_secs(*secs)).await;
 ///         Python::with_gil(|py| Ok(py.None()))
 ///     })?.into())
@@ -305,7 +307,7 @@ where
 ///             pyo3_asyncio::tokio::scope_local(event_loop, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
-///                     pyo3_asyncio::into_future(
+///                     pyo3_asyncio::into_future_with_loop(
 ///                         pyo3_asyncio::tokio::task_event_loop().unwrap().as_ref(py),
 ///                         py_future.as_ref(py)
 ///                     )
@@ -320,9 +322,9 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py_with_loop<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    generic::local_future_into_py::<TokioRuntime, _>(event_loop, fut)
+    generic::local_future_into_py_with_loop::<TokioRuntime, _>(event_loop, fut)
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -246,6 +246,39 @@ where
     generic::run_until_complete::<TokioRuntime, _>(py, fut)
 }
 
+/// Run the event loop until the given Future completes
+///
+/// # Arguments
+/// * `py` - The current PyO3 GIL guard
+/// * `fut` - The future to drive to completion
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// #
+/// # use pyo3::prelude::*;
+/// #
+/// fn main() {
+///     Python::with_gil(|py| {
+///         pyo3_asyncio::tokio::run(py, async move {
+///             tokio::time::sleep(Duration::from_secs(1)).await;
+///             Ok(())
+///         })
+///         .map_err(|e| {
+///             e.print_and_set_sys_last_vars(py);  
+///         })
+///         .unwrap();
+///     })
+/// }
+/// ```
+pub fn run<F>(py: Python, fut: F) -> PyResult<()>
+where
+    F: Future<Output = PyResult<()>> + Send + 'static,
+{
+    generic::run::<TokioRuntime, F>(py, fut)
+}
+
 /// Convert a Rust Future into a Python awaitable
 ///
 /// # Arguments

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -220,6 +220,7 @@ pub fn init_current_thread_once() {
 /// #     .build()
 /// #     .expect("Couldn't build the runtime");
 /// #
+/// # pyo3::prepare_freethreaded_python();
 /// # Python::with_gil(|py| {
 /// # pyo3_asyncio::with_runtime(py, || {
 /// # pyo3_asyncio::tokio::init_current_thread();

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -284,10 +284,10 @@ where
 ///     let secs = Rc::new(secs);
 ///     let event_loop = pyo3_asyncio::tokio::task_event_loop().unwrap();
 ///
-///     pyo3_asyncio::tokio::local_future_into_py(event_loop.as_ref(py), async move {
+///     Ok(pyo3_asyncio::tokio::local_future_into_py(event_loop.as_ref(py), async move {
 ///         tokio::time::sleep(Duration::from_secs(*secs)).await;
 ///         Python::with_gil(|py| Ok(py.None()))
-///     })
+///     })?.into())
 /// }
 ///
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
@@ -320,7 +320,7 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<PyObject>
+pub fn local_future_into_py<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {


### PR DESCRIPTION
Ongoing work for #29 

- [x] Get rid of the ThreadPoolExecutor initialization and cleanup
  - It still exists in `try_init` and `try_close`, but since `try_init` should only be called when using the 0.13 API and `try_close` only performs the cleanup if `try_init` was called, it has effectively been removed for 0.14
- [x] Stop recommending that people call try_init in their module export function.
  - try_init might actually be completely unnecessary after these changes regardless of whether the crate is an application or a library
- [x] Stop caching the result of get_event_loop at the start to support multiple event loops
- [x] Change/Add conversions that accept a Python event loop as a parameter since these conversions might not take place on a thread that is aware of the relevant asyncio event loop.
  - Currently, I've just changed the conversions to accept a loop parameter. I think the best way forward is to provide both sets of conversions:
    - conversions with an explicit event loop parameter 
    - conversions with an implicit loop parameter taken from the task local event loop if a local key exists or `asyncio.get_event_loop` if it does not.
      - This will be a simpler mode that can be called from _either_ a Python asyncio context or a Rust async task. They are not however a one-size fits all solution since plain Rust threads will not have the asyncio context or a task-local context to get a reference to the event loop.

These changes unfortunately add more nuance to the conversions. It's more important to be aware of whether a conversion is taking place on a Python asyncio-aware thread, an async Rust task, or a plain Rust thread.

I do think these changes make the library more _correct_, but I also think that it's important to help existing users transition. There was some uncertainty in the discussions for #29 about whether or not a compatibility layer was warranted, but after implementing some of these changes I'm even more inclined to say that it's necessary.

- [x] Keep 0.13 API alongside these changes 
  - I think the 0.13 API can be implemented on top of these changes as long as it just passes the cached event loop to the new conversions
  - Also, I'm pretty sure that there's no overlap, so the 0.13 API could remain the same
    - `try_init` is slated to be removed
    - `try_close` can keep the `ThreadPoolExecutor` logic provided that it only closes the executor down if `try_init` was previously called
    - `into_future` needs to be moved into the runtime-specific modules, the one currently in lib.rs should be renamed to `into_future_with_loop` to denote the explicit loop parameter
    - `into_coroutine` was going to be renamed to `future_into_py` anyway
- [x] Restrict access to the 0.13 API - `"compat"` feature gate or deprecation attributes, maybe both with default features=["compat"]?

The compat layer should make it much easier for downstream developers to transition to the newer, more correct, API. Ideally upgrading to 0.14 should not break existing users, but still encourage them to start using the more correct API .

- [x] Document the different initialization approachs - new concerns, 0.13 problems, 0.14 fixes (i.e. `asyncio.run` should now be possible)
  - [x] Merge in #33?
  - [x] Migration guide for 0.13 -> 0.14
    - [x] Mention that `#[main]` attributes call `pyo3::prepare_freethreaded_python` regardless of pyo3's `auto-initialize` feature
    - [x] Mention that when using pyo3-asyncio function as main coroutine in `asyncio.run`, `get_running_loop` doesn't work. The top level coroutine for `asyncio.run` should be a Python coroutine.
    - [x] Notes about 0.13 deprecation (how long will it be supported? `#[allow(deprecated)]` to suppress warnings)
  - [x] Guidelines for which conversion variant to use, `scope` rules, thread awareness
  - [x] Python executor no longer manually configured at the start. (didn't seem to have a noticeable effect in tests after removal)
  - [x] Different Python event loops like uvloop
  - [x] Open PR for pyo3 async/await guide
  - [x] Integrate updated pyo3 async/await guide into API docs (no reason why that guide shouldn't be here as well)
- [x] Testing
  - [x] `pytest` regression testing (multiple `asyncio.run` calls?)
- [ ] Documentation review - a lot of API calls are affected by this, so it'd be good to just review all of the docs to make sure they are up-to-date and accurate.