### PR TITLE
Generic returns for `future_into_py`, `local_future_into_py`, `run_until_complete`, `run` variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 fn rust_sleep(py: Python) -> PyResult<&PyAny> {
     pyo3_asyncio::async_std::future_into_py(py, async {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
-        Ok(Python::with_gil(|py| py.None()))
+        Ok(())
     })
 }
 
@@ -166,7 +166,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 fn rust_sleep(py: Python) -> PyResult<&PyAny> {
     pyo3_asyncio::tokio::future_into_py(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        Ok(Python::with_gil(|py| py.None()))
+        Ok(())
     })
 }
 
@@ -283,7 +283,7 @@ async fn rust_sleep() {
 fn call_rust_sleep(py: Python) -> PyResult<&PyAny> {
     pyo3_asyncio::async_std::future_into_py(py, async move {
         rust_sleep().await;
-        Ok(Python::with_gil(|py| py.None()))
+        Ok(())
     })
 }
 ```
@@ -433,7 +433,7 @@ use pyo3::{prelude::*, wrap_pyfunction};
 fn rust_sleep(py: Python) -> PyResult<&PyAny> {
     pyo3_asyncio::tokio::future_into_py(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        Ok(Python::with_gil(|py| py.None()))
+        Ok(())
     })
 }
 

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -27,7 +27,7 @@ fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
 
     pyo3_asyncio::async_std::future_into_py(py, async move {
         task::sleep(Duration::from_secs(secs)).await;
-        Python::with_gil(|py| Ok(py.None()))
+        Ok(())
     })
 }
 

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -135,9 +135,10 @@ async fn test_other_awaitables() -> PyResult<()> {
 #[pyo3_asyncio::async_std::test]
 async fn test_panic() -> PyResult<()> {
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        pyo3_asyncio::async_std::into_future(pyo3_asyncio::async_std::future_into_py(py, async {
-            panic!("this panic was intentional!")
-        })?)
+        pyo3_asyncio::async_std::into_future(pyo3_asyncio::async_std::future_into_py::<_, ()>(
+            py,
+            async { panic!("this panic was intentional!") },
+        )?)
     })?;
 
     match fut.await {

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -26,7 +26,7 @@ fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
 
     pyo3_asyncio::tokio::future_into_py(py, async move {
         tokio::time::sleep(Duration::from_secs(secs)).await;
-        Python::with_gil(|py| Ok(py.None()))
+        Ok(())
     })
 }
 

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -149,7 +149,7 @@ fn test_local_future_into_py(event_loop: PyObject) -> PyResult<()> {
 #[pyo3_asyncio::tokio::test]
 async fn test_panic() -> PyResult<()> {
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        pyo3_asyncio::tokio::into_future(pyo3_asyncio::tokio::future_into_py(py, async {
+        pyo3_asyncio::tokio::into_future(pyo3_asyncio::tokio::future_into_py::<_, ()>(py, async {
             panic!("this panic was intentional!")
         })?)
     })?;

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -266,11 +266,12 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
+pub fn future_into_py_with_loop<F, T>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::future_into_py_with_loop::<AsyncStdRuntime, F>(event_loop, fut)
+    generic::future_into_py_with_loop::<AsyncStdRuntime, F, T>(event_loop, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -296,11 +297,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::future_into_py::<AsyncStdRuntime, _>(py, fut)
+    generic::future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -261,7 +261,7 @@ where
 ///         pyo3_asyncio::async_std::get_current_loop(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Ok(())
 ///         }
 ///     )
 /// }
@@ -293,7 +293,7 @@ where
 ///     let secs = secs.extract()?;
 ///     pyo3_asyncio::async_std::future_into_py(py, async move {
 ///         async_std::task::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
+///         Ok(())
 ///     })
 /// }
 /// ```
@@ -327,7 +327,7 @@ where
 ///         pyo3_asyncio::async_std::get_current_loop(py)?,
 ///         async move {
 ///             async_std::task::sleep(Duration::from_secs(*secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Ok(())
 ///         }
 ///     )?.into())
 /// }
@@ -346,11 +346,12 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py_with_loop<F, T>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + 'static,
+    F: Future<Output = PyResult<T>> + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::local_future_into_py_with_loop::<AsyncStdRuntime, _>(event_loop, fut)
+    generic::local_future_into_py_with_loop::<AsyncStdRuntime, _, T>(event_loop, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -373,7 +374,7 @@ where
 ///     let secs = Rc::new(secs);
 ///     pyo3_asyncio::async_std::local_future_into_py(py, async move {
 ///         async_std::task::sleep(Duration::from_secs(*secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
+///         Ok(())
 ///     })
 /// }
 ///
@@ -391,11 +392,12 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + 'static,
+    F: Future<Output = PyResult<T>> + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::local_future_into_py::<AsyncStdRuntime, _>(py, fut)
+    generic::local_future_into_py::<AsyncStdRuntime, _, T>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -161,11 +161,12 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
 /// # .unwrap();
 /// # });
 /// ```
-pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
+pub fn run_until_complete<F, T>(event_loop: &PyAny, fut: F) -> PyResult<T>
 where
-    F: Future<Output = PyResult<()>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: Send + Sync + 'static,
 {
-    generic::run_until_complete::<AsyncStdRuntime, _>(event_loop, fut)
+    generic::run_until_complete::<AsyncStdRuntime, _, T>(event_loop, fut)
 }
 
 /// Run the event loop until the given Future completes
@@ -197,11 +198,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn run<F>(py: Python, fut: F) -> PyResult<()>
+pub fn run<F, T>(py: Python, fut: F) -> PyResult<T>
 where
-    F: Future<Output = PyResult<()>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: Send + Sync + 'static,
 {
-    generic::run::<AsyncStdRuntime, F>(py, fut)
+    generic::run::<AsyncStdRuntime, F, T>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -274,7 +274,7 @@ where
 ///         pyo3_asyncio::tokio::get_current_loop(py)?,
 ///         async move {
 ///             tokio::time::sleep(Duration::from_secs(secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Ok(())
 ///         }
 ///     )
 /// }
@@ -306,7 +306,7 @@ where
 ///     let secs = secs.extract()?;
 ///     pyo3_asyncio::tokio::future_into_py(py, async move {
 ///         tokio::time::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
+///         Ok(())
 ///     })
 /// }
 /// ```
@@ -341,7 +341,7 @@ where
 ///         pyo3_asyncio::tokio::get_current_loop(py)?,
 ///         async move {
 ///             tokio::time::sleep(Duration::from_secs(*secs)).await;
-///             Python::with_gil(|py| Ok(py.None()))
+///             Ok(())
 ///         }
 ///     )
 /// }
@@ -375,11 +375,12 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py_with_loop<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py_with_loop<'p, F, T>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + 'static,
+    F: Future<Output = PyResult<T>> + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::local_future_into_py_with_loop::<TokioRuntime, _>(event_loop, fut)
+    generic::local_future_into_py_with_loop::<TokioRuntime, _, T>(event_loop, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -402,7 +403,7 @@ where
 ///     let secs = Rc::new(secs);
 ///     pyo3_asyncio::tokio::local_future_into_py(py, async move {
 ///         tokio::time::sleep(Duration::from_secs(*secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
+///         Ok(())
 ///     })
 /// }
 ///
@@ -435,11 +436,12 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
-pub fn local_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+pub fn local_future_into_py<F, T>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + 'static,
+    F: Future<Output = PyResult<T>> + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::local_future_into_py::<TokioRuntime, _>(py, fut)
+    generic::local_future_into_py::<TokioRuntime, _, T>(py, fut)
 }
 
 /// Convert a Python `awaitable` into a Rust Future

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -279,11 +279,12 @@ where
 ///     )
 /// }
 /// ```
-pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
+pub fn future_into_py_with_loop<F, T>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::future_into_py_with_loop::<TokioRuntime, F>(event_loop, fut)
+    generic::future_into_py_with_loop::<TokioRuntime, F, T>(event_loop, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable
@@ -309,11 +310,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
+pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: IntoPy<PyObject>,
 {
-    generic::future_into_py::<TokioRuntime, _>(py, fut)
+    generic::future_into_py::<TokioRuntime, _, T>(py, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -178,11 +178,12 @@ fn multi_thread() -> Builder {
 /// # .unwrap();
 /// # });
 /// ```
-pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
+pub fn run_until_complete<F, T>(event_loop: &PyAny, fut: F) -> PyResult<T>
 where
-    F: Future<Output = PyResult<()>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: Send + Sync + 'static,
 {
-    generic::run_until_complete::<TokioRuntime, _>(event_loop, fut)
+    generic::run_until_complete::<TokioRuntime, _, T>(event_loop, fut)
 }
 
 /// Run the event loop until the given Future completes
@@ -211,11 +212,12 @@ where
 ///     })
 /// }
 /// ```
-pub fn run<F>(py: Python, fut: F) -> PyResult<()>
+pub fn run<F, T>(py: Python, fut: F) -> PyResult<T>
 where
-    F: Future<Output = PyResult<()>> + Send + 'static,
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: Send + Sync + 'static,
 {
-    generic::run::<TokioRuntime, F>(py, fut)
+    generic::run::<TokioRuntime, F, T>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable


### PR DESCRIPTION
Motivation in #42 

Not sure when this will be merged. It's a breaking change, so 0.15 at the very least. Changes to `future_into_py` and `local_future_into_py` may add some friction downstream if return types cannot be inferred (i.e. if return value uses ".into()", etc).