### PR TITLE
Modified API to preserve contextvars.Context similar to Event Loop

### DIFF
--- a/pytests/test_async_std_uvloop.rs
+++ b/pytests/test_async_std_uvloop.rs
@@ -1,7 +1,6 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {

--- a/pytests/test_tokio_current_thread_uvloop.rs
+++ b/pytests/test_tokio_current_thread_uvloop.rs
@@ -1,7 +1,7 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
+
     pyo3::prepare_freethreaded_python();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();

--- a/pytests/test_tokio_multi_thread_uvloop.rs
+++ b/pytests/test_tokio_multi_thread_uvloop.rs
@@ -1,7 +1,7 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
+
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -130,6 +130,12 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
     generic::get_current_loop::<AsyncStdRuntime>(py)
 }
 
+/// Either copy the task locals from the current task OR get the current running loop and
+/// contextvars from Python.
+pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
+    generic::get_current_locals::<AsyncStdRuntime>(py)
+}
+
 /// Run the event loop until the given Future completes
 ///
 /// The event loop runs until the given future is complete.

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -11,7 +11,7 @@ use pyo3::{prelude::*, PyNativeType};
 #[allow(deprecated)]
 use crate::{
     asyncio, call_soon_threadsafe, close, create_future, dump_err, err::RustPanic, get_event_loop,
-    get_running_loop, into_future_with_loop,
+    get_running_loop, into_future_with_locals, TaskLocals,
 };
 
 /// Generic utilities for a JoinError
@@ -27,13 +27,6 @@ pub trait Runtime {
     /// A future that completes with the result of the spawned task
     type JoinHandle: Future<Output = Result<(), Self::JoinError>> + Send;
 
-    /// Set the task local event loop for the given future
-    fn scope<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
-    where
-        F: Future<Output = R> + Send + 'static;
-    /// Get the task local event loop for the current task
-    fn get_task_event_loop(py: Python) -> Option<&PyAny>;
-
     /// Spawn a future onto this runtime's event loop
     fn spawn<F>(fut: F) -> Self::JoinHandle
     where
@@ -42,15 +35,29 @@ pub trait Runtime {
 
 /// Extension trait for async/await runtimes that support spawning local tasks
 pub trait SpawnLocalExt: Runtime {
-    /// Set the task local event loop for the given !Send future
-    fn scope_local<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
-    where
-        F: Future<Output = R> + 'static;
-
     /// Spawn a !Send future onto this runtime's event loop
     fn spawn_local<F>(fut: F) -> Self::JoinHandle
     where
         F: Future<Output = ()> + 'static;
+}
+
+/// Exposes the utilities necessary for using task-local data in the Runtime
+pub trait ContextExt: Runtime {
+    /// Set the task local event loop for the given future
+    fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+    where
+        F: Future<Output = R> + Send + 'static;
+
+    /// Get the task locals for the current task
+    fn get_task_locals() -> Option<TaskLocals>;
+}
+
+/// Adds the ability to scope task-local data for !Send futures
+pub trait LocalContextExt: Runtime {
+    /// Set the task local event loop for the given !Send future
+    fn scope_local<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+    where
+        F: Future<Output = R> + 'static;
 }
 
 /// Get the current event loop from either Python or Rust async task local context
@@ -60,10 +67,10 @@ pub trait SpawnLocalExt: Runtime {
 /// with the current OS thread.
 pub fn get_current_loop<R>(py: Python) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: ContextExt,
 {
-    if let Some(event_loop) = R::get_task_event_loop(py) {
-        Ok(event_loop)
+    if let Some(locals) = R::get_task_locals() {
+        Ok(locals.event_loop.into_ref(py))
     } else {
         get_running_loop(py)
     }
@@ -149,13 +156,18 @@ where
 /// ```
 pub fn run_until_complete<R, F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let coro = future_into_py_with_loop::<R, _>(event_loop, async move {
-        fut.await?;
-        Ok(Python::with_gil(|py| py.None()))
-    })?;
+    let py = event_loop.py();
+    let coro = future_into_py_with_locals::<R, _>(
+        py,
+        TaskLocals::new(event_loop).copy_context(py)?,
+        async move {
+            fut.await?;
+            Ok(Python::with_gil(|py| py.None()))
+        },
+    )?;
 
     event_loop.call_method1("run_until_complete", (coro,))?;
 
@@ -237,7 +249,7 @@ where
 /// ```
 pub fn run<R, F>(py: Python, fut: F) -> PyResult<()>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
     let event_loop = asyncio(py)?.call_method0("new_event_loop")?;
@@ -254,14 +266,17 @@ fn cancelled(future: &PyAny) -> PyResult<bool> {
 }
 
 fn set_result(event_loop: &PyAny, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+    let py = event_loop.py();
+    let none = py.None().into_ref(py);
+
     match result {
         Ok(val) => {
             let set_result = future.getattr("set_result")?;
-            call_soon_threadsafe(event_loop, (set_result, val))?;
+            call_soon_threadsafe(event_loop, none, (set_result, val))?;
         }
         Err(err) => {
             let set_exception = future.getattr("set_exception")?;
-            call_soon_threadsafe(event_loop, (set_exception, err))?;
+            call_soon_threadsafe(event_loop, none, (set_exception, err))?;
         }
     }
 
@@ -369,9 +384,156 @@ pub fn into_future<R>(
     awaitable: &PyAny,
 ) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
 {
-    into_future_with_loop(get_current_loop::<R>(awaitable.py())?, awaitable)
+    into_future_with_locals(
+        &TaskLocals::from_current_context::<R>(awaitable.py())?,
+        awaitable,
+    )
+}
+
+/// Convert a Rust Future into a Python awaitable with a generic runtime
+///
+/// # Arguments
+/// * `locals` - The task-local data for Python
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl MyCustomRuntime {
+/// #     async fn sleep(_: Duration) {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop(py: Python) -> Option<&PyAny> {
+/// #         unreachable!()
+/// #     }
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///     pyo3_asyncio::generic::future_into_py_with_locals::<MyCustomRuntime, _>(
+///         py,
+///         TaskLocals::from_current_context::<MyCustomRuntime>(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+/// ```
+pub fn future_into_py_with_locals<R, F>(py: Python, locals: TaskLocals, fut: F) -> PyResult<&PyAny>
+where
+    R: Runtime + ContextExt,
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+
+    let py_fut = create_future(locals.event_loop.clone().into_ref(py))?;
+    py_fut.call_method1(
+        "add_done_callback",
+        (PyDoneCallback {
+            cancel_tx: Some(cancel_tx),
+        },),
+    )?;
+
+    let future_tx1 = PyObject::from(py_fut);
+    let future_tx2 = future_tx1.clone();
+
+    R::spawn(async move {
+        let locals2 = locals.clone();
+
+        if let Err(e) = R::spawn(async move {
+            let result = R::scope(
+                locals2.clone(),
+                Cancellable::new_with_cancel_rx(fut, cancel_rx),
+            )
+            .await;
+
+            Python::with_gil(move |py| {
+                if cancelled(future_tx1.as_ref(py))
+                    .map_err(dump_err(py))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+
+                let _ = set_result(locals2.event_loop.as_ref(py), future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py));
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if cancelled(future_tx2.as_ref(py))
+                        .map_err(dump_err(py))
+                        .unwrap_or(false)
+                    {
+                        return;
+                    }
+
+                    let _ = set_result(
+                        locals.event_loop.as_ref(py),
+                        future_tx2.as_ref(py),
+                        Err(RustPanic::new_err("rust future panicked")),
+                    )
+                    .map_err(dump_err(py));
+                });
+            }
+        }
+    });
+
+    Ok(py_fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -454,56 +616,11 @@ where
 /// ```
 pub fn future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let future_rx = create_future(event_loop)?;
-    let future_tx1 = PyObject::from(future_rx);
-    let future_tx2 = future_tx1.clone();
-
-    let event_loop = PyObject::from(event_loop);
-
-    R::spawn(async move {
-        let event_loop2 = event_loop.clone();
-
-        if let Err(e) = R::spawn(async move {
-            let result = R::scope(event_loop2.clone(), fut).await;
-
-            Python::with_gil(move |py| {
-                if cancelled(future_tx1.as_ref(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
-                    .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::with_gil(move |py| {
-                    if cancelled(future_tx2.as_ref(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let _ = set_result(
-                        event_loop.as_ref(py),
-                        future_tx2.as_ref(py),
-                        Err(RustPanic::new_err("rust future panicked")),
-                    )
-                    .map_err(dump_err(py));
-                });
-            }
-        }
-    });
-
-    Ok(future_rx)
+    let py = event_loop.py();
+    future_into_py_with_locals::<R, F>(py, TaskLocals::new(event_loop).copy_context(py)?, fut)
 }
 
 pin_project! {
@@ -672,24 +789,11 @@ impl PyDoneCallback {
 /// ```
 pub fn cancellable_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let (cancel_tx, cancel_rx) = oneshot::channel();
-
-    let py_fut = future_into_py_with_loop::<R, _>(
-        event_loop,
-        Cancellable::new_with_cancel_rx(fut, cancel_rx),
-    )?;
-
-    py_fut.call_method1(
-        "add_done_callback",
-        (PyDoneCallback {
-            cancel_tx: Some(cancel_tx),
-        },),
-    )?;
-
-    Ok(py_fut)
+    // cancellable futures became the default behaviour in 0.15
+    future_into_py_with_loop::<R, _>(event_loop, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -769,10 +873,10 @@ where
 /// ```
 pub fn future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
+    future_into_py_with_locals::<R, F>(py, TaskLocals::from_current_context::<R>(py)?, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -859,7 +963,7 @@ where
 /// ```
 pub fn cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
     cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
@@ -947,10 +1051,176 @@ where
 #[allow(deprecated)]
 pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
     Ok(future_into_py_with_loop::<R, F>(get_event_loop(py), fut)?.into())
+}
+
+/// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
+///
+/// # Arguments
+/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, SpawnLocalExt, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl MyCustomRuntime {
+/// #     async fn sleep(_: Duration) {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop(py: Python) -> Option<&PyAny> {
+/// #         unreachable!()
+/// #     }
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl SpawnLocalExt for MyCustomRuntime {
+/// #     fn scope_local<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+/// #     where
+/// #         F: Future<Output = R> + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #    
+/// #     fn spawn_local<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// use std::{rc::Rc, time::Duration};
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
+///     // Rc is !Send so it cannot be passed into pyo3_asyncio::generic::future_into_py
+///     let secs = Rc::new(secs);
+///
+///     pyo3_asyncio::generic::local_future_into_py_with_locals::<MyCustomRuntime, _>(
+///         py,
+///         TaskLocals::from_current_context::<MyCustomRuntime>(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(*secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+/// ```
+pub fn local_future_into_py_with_locals<R, F>(
+    py: Python,
+    locals: TaskLocals,
+    fut: F,
+) -> PyResult<&PyAny>
+where
+    R: SpawnLocalExt + LocalContextExt,
+    F: Future<Output = PyResult<PyObject>> + 'static,
+{
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+
+    let py_fut = create_future(locals.event_loop.clone().into_ref(py))?;
+    py_fut.call_method1(
+        "add_done_callback",
+        (PyDoneCallback {
+            cancel_tx: Some(cancel_tx),
+        },),
+    )?;
+
+    let future_tx1 = PyObject::from(py_fut);
+    let future_tx2 = future_tx1.clone();
+
+    R::spawn_local(async move {
+        let locals2 = locals.clone();
+
+        if let Err(e) = R::spawn_local(async move {
+            let result = R::scope_local(
+                locals2.clone(),
+                Cancellable::new_with_cancel_rx(fut, cancel_rx),
+            )
+            .await;
+
+            Python::with_gil(move |py| {
+                if cancelled(future_tx1.as_ref(py))
+                    .map_err(dump_err(py))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+
+                let _ = set_result(locals2.event_loop.as_ref(py), future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py));
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if cancelled(future_tx2.as_ref(py))
+                        .map_err(dump_err(py))
+                        .unwrap_or(false)
+                    {
+                        return;
+                    }
+
+                    let _ = set_result(
+                        locals.event_loop.as_ref(py),
+                        future_tx2.as_ref(py),
+                        Err(RustPanic::new_err("Rust future panicked")),
+                    )
+                    .map_err(dump_err(py));
+                });
+            }
+        }
+    });
+
+    Ok(py_fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1051,56 +1321,11 @@ where
 /// ```
 pub fn local_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: SpawnLocalExt,
+    R: Runtime + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let future_rx = create_future(event_loop)?;
-    let future_tx1 = PyObject::from(future_rx);
-    let future_tx2 = future_tx1.clone();
-
-    let event_loop = PyObject::from(event_loop);
-
-    R::spawn_local(async move {
-        let event_loop2 = event_loop.clone();
-
-        if let Err(e) = R::spawn_local(async move {
-            let result = R::scope_local(event_loop2.clone(), fut).await;
-
-            Python::with_gil(move |py| {
-                if cancelled(future_tx1.as_ref(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
-                    .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::with_gil(move |py| {
-                    if cancelled(future_tx2.as_ref(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let _ = set_result(
-                        event_loop.as_ref(py),
-                        future_tx2.as_ref(py),
-                        Err(RustPanic::new_err("Rust future panicked")),
-                    )
-                    .map_err(dump_err(py));
-                });
-            }
-        }
-    });
-
-    Ok(future_rx)
+    let py = event_loop.py();
+    local_future_into_py_with_locals::<R, F>(py, TaskLocals::new(event_loop).copy_context(py)?, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1211,24 +1436,11 @@ pub fn local_cancellable_future_into_py_with_loop<R, F>(
     fut: F,
 ) -> PyResult<&PyAny>
 where
-    R: Runtime + SpawnLocalExt,
+    R: Runtime + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let (cancel_tx, cancel_rx) = oneshot::channel();
-
-    let py_fut = local_future_into_py_with_loop::<R, _>(
-        event_loop,
-        Cancellable::new_with_cancel_rx(fut, cancel_rx),
-    )?;
-
-    py_fut.call_method1(
-        "add_done_callback",
-        (PyDoneCallback {
-            cancel_tx: Some(cancel_tx),
-        },),
-    )?;
-
-    Ok(py_fut)
+    // cancellable futures became the default in 0.15
+    local_future_into_py_with_loop::<R, F>(event_loop, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1326,7 +1538,7 @@ where
 /// ```
 pub fn local_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: SpawnLocalExt,
+    R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     local_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
@@ -1436,7 +1648,7 @@ where
 /// ```
 pub fn local_cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime + SpawnLocalExt,
+    R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     local_cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -129,6 +129,12 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
     generic::get_current_loop::<TokioRuntime>(py)
 }
 
+/// Either copy the task locals from the current task OR get the current running loop and
+/// contextvars from Python.
+pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
+    generic::get_current_locals::<TokioRuntime>(py)
+}
+
 /// Initialize the Tokio runtime with a custom build
 pub fn init(builder: Builder) {
     *TOKIO_BUILDER.lock().unwrap() = builder
@@ -431,8 +437,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| -> PyResult<PyObject> {
-///         Ok(pyo3_asyncio::tokio::get_current_loop(py)?.into())
+///     let locals = Python::with_gil(|py| -> PyResult<_> {
+///         pyo3_asyncio::tokio::get_current_locals(py)
 ///     })?;
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -442,7 +448,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -502,8 +508,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| -> PyResult<PyObject> {
-///         Ok(pyo3_asyncio::tokio::get_current_loop(py)?.into())
+///     let locals = Python::with_gil(|py| -> PyResult<_> {
+///         pyo3_asyncio::tokio::get_current_locals(py)
 ///     })?;
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -513,7 +519,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -565,8 +571,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| {
-///         PyObject::from(pyo3_asyncio::tokio::get_current_loop(py).unwrap())
+///     let locals = Python::with_gil(|py| {
+///         pyo3_asyncio::tokio::get_current_locals(py).unwrap()
 ///     });
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -576,7 +582,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -632,8 +638,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| {
-///         PyObject::from(pyo3_asyncio::tokio::get_current_loop(py).unwrap())
+///     let locals = Python::with_gil(|py| {
+///         pyo3_asyncio::tokio::get_current_locals(py).unwrap()
 ///     });
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -643,7 +649,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)


### PR DESCRIPTION
#52 brought a problem to my attention that this PR resolves. Unfortunately it comes at the cost of modifying the public API, but luckily it only touches upon the more niche options like scoping and custom runtimes. 

Since it's a public API change, this will be released under version 0.15.0. I also went ahead and made the cancellable future conversions the default behaviour in this PR as well.

I still need to touch up some of the docs and ensure that the guide takes these changes into account, but that might be wrapped up under a 0.15 release PR.