### PR TITLE
Release 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,11 +114,11 @@ pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.14.0", optio
 pyo3 = { version = "0.15", features = ["macros"] }
 
 [dependencies.async-std]
-version = "1.9"
+version = "1.10"
 features = ["unstable"]
 optional = true
 
 [dependencies.tokio]
-version = "1.9" 
+version = "1.13" 
 features = ["full"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio"
 description = "PyO3 utilities for Python's Asyncio library"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]
@@ -108,7 +108,7 @@ inventory = "0.1"
 once_cell = "1.5"
 pin-project-lite = "0.2"
 pyo3 = "0.15"
-pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.14.0", optional = true }
+pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.15.0", optional = true }
 
 [dev-dependencies]
 pyo3 = { version = "0.15", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > PyO3 Asyncio is a _brand new_ part of the broader PyO3 ecosystem. Feel free to open any issues for feature requests or bugfixes for this crate.
 
-__If you're a new-comer, the best way to get started is to read through the primer below! For `v0.13` users I highly recommend reading through the [migration section](#migrating-from-013-to-014) to get a general idea of what's changed in `v0.14`.__
+__If you're a new-comer, the best way to get started is to read through the primer below! For `v0.13` and `v0.14` users I highly recommend reading through the [migration section](#migration-guide) to get a general idea of what's changed in `v0.14` and `v0.15`.__
 
 ## PyO3 Asyncio Primer
 
@@ -521,7 +521,8 @@ fn main() -> PyResult<()> {
 - Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
 - Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://awestlake87.github.io/pyo3-asyncio/master/doc/pyo3_asyncio/testing)
 
-## Migrating from 0.13 to 0.14
+## Migration Guide
+### Migrating from 0.13 to 0.14
 
 So what's changed from `v0.13` to `v0.14`? 
 
@@ -615,7 +616,42 @@ __Before you get started, I personally recommend taking a look at [Event Loop Re
     - Replace `pyo3_asyncio::get_event_loop` with `pyo3_asyncio::<runtime>::get_current_loop`
 5. After all conversions have been replaced with their `v0.14` counterparts, `pyo3_asyncio::try_init` can safely be removed.
 
-> The `v0.13` API will likely still be supported in version `v0.15`, but no solid guarantees after that point.
+> The `v0.13` API has been removed in version `v0.15`
+
+### Migrating from 0.14 to 0.15
+
+There have been a few changes to the API in order to support proper cancellation from Python and the `contextvars` module.
+
+- Any instance of `cancellable_future_into_py` and `local_cancellable_future_into_py` conversions can be replaced with their`future_into_py` and `local_future_into_py` counterparts. 
+  > Cancellation support became the default behaviour in 0.15.
+- Instances of `*_with_loop` conversions should be replaced with the newer `*_with_locals` conversions.
+  ```rust no_run
+  use pyo3::prelude::*;
+
+  Python::with_gil(|py| -> PyResult<()> {
+      let event_loop = pyo3_asyncio::get_running_loop(py)?;
+
+      // *_with_loop conversions in 0.14
+      let fut = pyo3_asyncio::tokio::future_into_py_with_loop(
+          event_loop, 
+          async move { Ok(Python::with_gil(|py| py.None())) }
+      )?;
+      // should be replaced with *_with_locals in 0.15
+      //
+      // contextvars can be copied with `copy_context` or supplied 
+      // manually via `with_context`
+      let fut = pyo3_asyncio::tokio::future_into_py_with_locals(
+          py, 
+          pyo3_asyncio::TaskLocals::new(event_loop).copy_context(py)?, 
+          async move { Ok(()) }
+      )?;
+
+      Ok(())
+  });
+  ```
+- `scope` and `scope_local` variants now accept `TaskLocals` instead of `event_loop`. You can usually just replace the `event_loop` with `pyo3_asyncio::TaskLocals::new(event_loop).copy_context(py)?`.
+- Return types for `future_into_py`, `future_into_py_with_locals` `local_future_into_py`, and `local_future_into_py_with_locals` are now constrained by the bound `IntoPy<PyObject>` instead of requiring the return type to be `PyObject`. This can make the return types for futures more flexible, but inference can also fail when the concrete type is ambiguous (for example when using `into()`). Sometimes the `into()` can just be removed, 
+- `run`, and `run_until_complete` can now return any `Send + 'static` value.
 
 ## Known Problems
 

--- a/pyo3-asyncio-macros/Cargo.toml
+++ b/pyo3-asyncio-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio-macros"
 description = "Proc Macro Attributes for PyO3 Asyncio"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "../README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -1,6 +1,7 @@
 use std::{thread, time::Duration};
 
 use pyo3::prelude::*;
+use pyo3_asyncio::TaskLocals;
 
 pub(super) const TEST_MOD: &'static str = r#"
 import asyncio 
@@ -17,8 +18,8 @@ pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
         let test_mod =
             PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?;
 
-        pyo3_asyncio::into_future_with_loop(
-            event_loop.as_ref(py),
+        pyo3_asyncio::into_future_with_locals(
+            &TaskLocals::new(event_loop.as_ref(py)),
             test_mod.call_method1("py_sleep", (1.into_py(py),))?,
         )
     })?;
@@ -61,7 +62,7 @@ pub(super) async fn test_other_awaitables(event_loop: PyObject) -> PyResult<()> 
             ),
         )?;
 
-        pyo3_asyncio::into_future_with_loop(event_loop.as_ref(py), task)
+        pyo3_asyncio::into_future_with_locals(&TaskLocals::new(event_loop.as_ref(py)), task)
     })?;
 
     fut.await?;

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -29,20 +29,6 @@ pub(super) async fn test_into_future(event_loop: PyObject) -> PyResult<()> {
     Ok(())
 }
 
-#[allow(deprecated)]
-pub(super) async fn test_into_future_0_13() -> PyResult<()> {
-    let fut = Python::with_gil(|py| {
-        let test_mod =
-            PyModule::from_code(py, TEST_MOD, "test_rust_coroutine/test_mod.py", "test_mod")?;
-
-        pyo3_asyncio::into_future(test_mod.call_method1("py_sleep", (1.into_py(py),))?)
-    })?;
-
-    fut.await?;
-
-    Ok(())
-}
-
 pub(super) fn test_blocking_sleep() -> PyResult<()> {
     thread::sleep(Duration::from_secs(1));
     Ok(())

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -319,9 +319,5 @@ fn test_contextvars() -> PyResult<()> {
 fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
-    Python::with_gil(|py| {
-        // into_coroutine requires the 0.13 API
-        pyo3_asyncio::try_init(py)?;
-        pyo3_asyncio::async_std::run(py, pyo3_asyncio::testing::main())
-    })
+    Python::with_gil(|py| pyo3_asyncio::async_std::run(py, pyo3_asyncio::testing::main()))
 }

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -16,55 +16,12 @@ use pyo3::{
 use pyo3_asyncio::TaskLocals;
 
 #[pyfunction]
-#[allow(deprecated)]
-fn sleep_into_coroutine(py: Python, secs: &PyAny) -> PyResult<PyObject> {
-    let secs = secs.extract()?;
-
-    pyo3_asyncio::async_std::into_coroutine(py, async move {
-        task::sleep(Duration::from_secs(secs)).await;
-        Python::with_gil(|py| Ok(py.None()))
-    })
-}
-
-#[pyfunction]
 fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
     let secs = secs.extract()?;
 
     pyo3_asyncio::async_std::future_into_py(py, async move {
         task::sleep(Duration::from_secs(secs)).await;
         Python::with_gil(|py| Ok(py.None()))
-    })
-}
-
-#[pyo3_asyncio::async_std::test]
-fn test_into_coroutine() -> PyResult<()> {
-    #[allow(deprecated)]
-    Python::with_gil(|py| {
-        let sleeper_mod = PyModule::new(py, "rust_sleeper")?;
-
-        sleeper_mod.add_wrapped(wrap_pyfunction!(sleep_into_coroutine))?;
-
-        let test_mod = PyModule::from_code(
-            py,
-            common::TEST_MOD,
-            "test_into_coroutine_mod.py",
-            "test_into_coroutine_mod",
-        )?;
-
-        let fut = pyo3_asyncio::into_future(test_mod.call_method1(
-            "sleep_for_1s",
-            (sleeper_mod.getattr("sleep_into_coroutine")?,),
-        )?)?;
-
-        pyo3_asyncio::async_std::run_until_complete(
-            pyo3_asyncio::get_event_loop(py),
-            async move {
-                fut.await?;
-                Ok(())
-            },
-        )?;
-
-        Ok(())
     })
 }
 
@@ -120,11 +77,6 @@ async fn test_into_future() -> PyResult<()> {
             .into()
     }))
     .await
-}
-
-#[pyo3_asyncio::async_std::test]
-async fn test_into_future_0_13() -> PyResult<()> {
-    common::test_into_future_0_13().await
 }
 
 #[pyo3_asyncio::async_std::test]

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -180,15 +180,13 @@ async fn test_cancel() -> PyResult<()> {
 
     let py_future = Python::with_gil(|py| -> PyResult<PyObject> {
         let completed = Arc::clone(&completed);
-        Ok(
-            pyo3_asyncio::async_std::cancellable_future_into_py(py, async move {
-                async_std::task::sleep(Duration::from_secs(1)).await;
-                *completed.lock().unwrap() = true;
+        Ok(pyo3_asyncio::async_std::future_into_py(py, async move {
+            async_std::task::sleep(Duration::from_secs(1)).await;
+            *completed.lock().unwrap() = true;
 
-                Ok(Python::with_gil(|py| py.None()))
-            })?
-            .into(),
-        )
+            Ok(Python::with_gil(|py| py.None()))
+        })?
+        .into())
     })?;
 
     if let Err(e) = Python::with_gil(|py| -> PyResult<_> {
@@ -228,15 +226,13 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 
         let py_future = Python::with_gil(|py| -> PyResult<PyObject> {
             let completed = Arc::clone(&completed);
-            Ok(
-                pyo3_asyncio::async_std::cancellable_future_into_py(py, async move {
-                    async_std::task::sleep(Duration::from_secs(1)).await;
-                    *completed.lock().unwrap() = true;
+            Ok(pyo3_asyncio::async_std::future_into_py(py, async move {
+                async_std::task::sleep(Duration::from_secs(1)).await;
+                *completed.lock().unwrap() = true;
 
-                    Ok(Python::with_gil(|py| py.None()))
-                })?
-                .into(),
-            )
+                Ok(Python::with_gil(|py| py.None()))
+            })?
+            .into())
         })?;
 
         if let Err(e) = Python::with_gil(|py| -> PyResult<_> {

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -347,9 +347,15 @@ asyncio.run(main())
 #[pyo3_asyncio::async_std::test]
 fn test_contextvars() -> PyResult<()> {
     Python::with_gil(|py| {
+        let contextvars = match py.import("contextvars") {
+            Ok(contextvars) => contextvars,
+            // Python 3.6 does not support contextvars, so early-out here
+            Err(_) => return Ok(()),
+        };
+
         let d = [
             ("asyncio", py.import("asyncio")?.into()),
-            ("contextvars", py.import("contextvars")?.into()),
+            ("contextvars", contextvars.into()),
             ("cvars_mod", wrap_pymodule!(cvars_mod)(py)),
         ]
         .into_py_dict(py);

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -117,7 +117,7 @@ async fn test_local_future_into_py() -> PyResult<()> {
 
         let py_future = pyo3_asyncio::async_std::local_future_into_py(py, async move {
             async_std::task::sleep(Duration::from_secs(*non_send_secs)).await;
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })?;
 
         pyo3_asyncio::async_std::into_future(py_future)
@@ -137,7 +137,7 @@ async fn test_cancel() -> PyResult<()> {
             async_std::task::sleep(Duration::from_secs(1)).await;
             *completed.lock().unwrap() = true;
 
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })?
         .into())
     })?;
@@ -183,7 +183,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
                 async_std::task::sleep(Duration::from_secs(1)).await;
                 *completed.lock().unwrap() = true;
 
-                Ok(Python::with_gil(|py| py.None()))
+                Ok(())
             })?
             .into())
         })?;
@@ -224,7 +224,7 @@ fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     fn sleep(py: Python) -> PyResult<&PyAny> {
         pyo3_asyncio::async_std::future_into_py(py, async move {
             async_std::task::sleep(Duration::from_millis(500)).await;
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })
     }
 
@@ -273,7 +273,7 @@ fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
             })?
             .await?;
 
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })
     }
 

--- a/pytests/test_async_std_uvloop.rs
+++ b/pytests/test_async_std_uvloop.rs
@@ -1,7 +1,6 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {

--- a/pytests/test_tokio_current_thread_asyncio.rs
+++ b/pytests/test_tokio_current_thread_asyncio.rs
@@ -8,9 +8,6 @@ fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        // into_coroutine requires the 0.13 API
-        pyo3_asyncio::try_init(py)?;
-
         let mut builder = tokio::runtime::Builder::new_current_thread();
         builder.enable_all();
 

--- a/pytests/test_tokio_current_thread_uvloop.rs
+++ b/pytests/test_tokio_current_thread_uvloop.rs
@@ -1,7 +1,7 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
+
     pyo3::prepare_freethreaded_python();
 
     let mut builder = tokio::runtime::Builder::new_current_thread();

--- a/pytests/test_tokio_multi_thread_asyncio.rs
+++ b/pytests/test_tokio_multi_thread_asyncio.rs
@@ -7,9 +7,5 @@ use pyo3::prelude::*;
 fn main() -> pyo3::PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
-    Python::with_gil(|py| {
-        // into_coroutine requires the 0.13 API
-        pyo3_asyncio::try_init(py)?;
-        pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main())
-    })
+    Python::with_gil(|py| pyo3_asyncio::tokio::run(py, pyo3_asyncio::testing::main()))
 }

--- a/pytests/test_tokio_multi_thread_uvloop.rs
+++ b/pytests/test_tokio_multi_thread_uvloop.rs
@@ -1,7 +1,7 @@
-use pyo3::{prelude::*, types::PyType};
-
 #[cfg(not(target_os = "windows"))]
-fn main() -> PyResult<()> {
+fn main() -> pyo3::PyResult<()> {
+    use pyo3::{prelude::*, types::PyType};
+
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -345,9 +345,15 @@ asyncio.run(main())
 #[pyo3_asyncio::async_std::test]
 fn test_contextvars() -> PyResult<()> {
     Python::with_gil(|py| {
+        let contextvars = match py.import("contextvars") {
+            Ok(contextvars) => contextvars,
+            // Python 3.6 does not support contextvars, so early-out here
+            Err(_) => return Ok(()),
+        };
+
         let d = [
             ("asyncio", py.import("asyncio")?.into()),
-            ("contextvars", py.import("contextvars")?.into()),
+            ("contextvars", contextvars.into()),
             ("cvars_mod", wrap_pymodule!(cvars_mod)(py)),
         ]
         .into_py_dict(py);

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -95,7 +95,7 @@ fn test_local_future_into_py(event_loop: PyObject) -> PyResult<()> {
                 TaskLocals::new(event_loop.as_ref(py)),
                 async move {
                     tokio::time::sleep(Duration::from_secs(*non_send_secs)).await;
-                    Ok(Python::with_gil(|py| py.None()))
+                    Ok(())
                 },
             )?;
 
@@ -140,7 +140,7 @@ async fn test_cancel() -> PyResult<()> {
             tokio::time::sleep(Duration::from_secs(1)).await;
             *completed.lock().unwrap() = true;
 
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })?
         .into())
     })?;
@@ -187,7 +187,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
                 Ok(pyo3_asyncio::tokio::local_future_into_py(py, async move {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     *completed.lock().unwrap() = true;
-                    Ok(Python::with_gil(|py| py.None()))
+                    Ok(())
                 })?
                 .into())
             })?;
@@ -230,7 +230,7 @@ fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     fn sleep(py: Python) -> PyResult<&PyAny> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })
     }
 
@@ -277,7 +277,7 @@ fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
             Python::with_gil(|py| pyo3_asyncio::tokio::into_future(callback.as_ref(py).call0()?))?
                 .await?;
 
-            Ok(Python::with_gil(|py| py.None()))
+            Ok(())
         })
     }
 

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -276,6 +276,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::future_into_py_with_locals instead"
+)]
 pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -316,6 +320,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::future_into_py_with_locals instead"
+)]
 pub fn cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -383,6 +391,10 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::future_into_py instead"
+)]
 pub fn cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -431,6 +443,10 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::local_future_into_py_with_locals instead"
+)]
 pub fn local_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
@@ -486,6 +502,10 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::local_future_into_py_with_locals instead"
+)]
 pub fn local_cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
@@ -583,6 +603,10 @@ where
 /// # #[cfg(not(all(feature = "async-std-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::async_std::local_future_into_py instead"
+)]
 pub fn local_cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -130,6 +130,12 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
     generic::get_current_loop::<AsyncStdRuntime>(py)
 }
 
+/// Either copy the task locals from the current task OR get the current running loop and
+/// contextvars from Python.
+pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
+    generic::get_current_locals::<AsyncStdRuntime>(py)
+}
+
 /// Run the event loop until the given Future completes
 ///
 /// The event loop runs until the given future is complete.

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -156,20 +156,14 @@ pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
 /// #
 /// # pyo3::prepare_freethreaded_python();
 /// #
-/// # Python::with_gil(|py| {
-/// # pyo3_asyncio::with_runtime(py, || {
+/// # Python::with_gil(|py| -> PyResult<()> {
 /// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_asyncio::async_std::run_until_complete(event_loop, async move {
 ///     async_std::task::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
 /// })?;
 /// # Ok(())
-/// # })
-/// # .map_err(|e| {
-/// #    e.print_and_set_sys_last_vars(py);  
-/// # })
-/// # .unwrap();
-/// # });
+/// # }).unwrap();
 /// ```
 pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
@@ -212,42 +206,6 @@ where
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
     generic::run::<AsyncStdRuntime, F>(py, fut)
-}
-
-/// Convert a Rust Future into a Python awaitable
-///
-/// # Arguments
-/// * `py` - The current PyO3 GIL guard
-/// * `fut` - The Rust future to be converted
-///
-/// # Examples
-///
-/// ```
-/// use std::time::Duration;
-///
-/// use pyo3::prelude::*;
-///
-/// /// Awaitable sleep function
-/// #[pyfunction]
-/// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
-///     let secs = secs.extract()?;
-///
-///     pyo3_asyncio::async_std::into_coroutine(py, async move {
-///         async_std::task::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
-///     })
-/// }
-/// ```
-#[deprecated(
-    since = "0.14.0",
-    note = "Use the pyo3_asyncio::async_std::future_into_py instead\n    (see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
-)]
-#[allow(deprecated)]
-pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
-where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
-{
-    generic::into_coroutine::<AsyncStdRuntime, _>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -211,6 +211,8 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
+/// __This function will be removed in `v0.16`__
+///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
 /// * `fut` - The Rust future to be converted
@@ -285,8 +287,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// __This function was deprecated in favor of [`future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
-/// replaced with [`future_into_py_with_locals`].__
+/// it became the default behaviour. In `v0.15`, any calls to this function should be replaced with
+/// [`future_into_py_with_locals`]__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -357,12 +361,11 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
-/// Unlike [`future_into_py`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
 /// __This function was deprecated in favor of [`future_into_py`] in `v0.15` because
 /// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`future_into_py`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -398,6 +401,8 @@ where
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -507,8 +512,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// __This function was deprecated in favor of [`local_future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// it became the default behaviour. In `v0.15`, any calls to this function should be
 /// replaced with [`local_future_into_py_with_locals`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -609,12 +616,11 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
-/// Unlike [`local_future_into_py`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
 /// __This function was deprecated in favor of [`local_future_into_py`] in `v0.15` because
 /// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`local_future_into_py`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -280,6 +280,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -324,6 +325,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -395,6 +397,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::future_into_py instead"
 )]
+#[allow(deprecated)]
 pub fn cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -447,6 +450,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::local_future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn local_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
@@ -506,6 +510,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::local_future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn local_cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
@@ -607,6 +612,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::async_std::local_future_into_py instead"
 )]
+#[allow(deprecated)]
 pub fn local_cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -251,8 +251,24 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
-/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `py` - PyO3 GIL guard
+/// * `locals` - The task locals for the given future
 /// * `fut` - The Rust future to be converted
 ///
 /// # Examples
@@ -329,6 +345,21 @@ where
 }
 
 /// Convert a Rust Future into a Python awaitable
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -457,8 +488,24 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
-/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `py` - PyO3 GIL guard
+/// * `locals` - The task locals for the given future
 /// * `fut` - The Rust future to be converted
 ///
 /// # Examples
@@ -569,6 +616,21 @@ where
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -140,8 +140,7 @@ pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
 ///
 /// The event loop runs until the given future is complete.
 ///
-/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`run_forever`](`crate::run_forever`)
+/// After this function returns, the event loop can be resumed with [`run_until_complete`]
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that should run the future

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -284,12 +284,9 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
-/// Unlike [`future_into_py_with_loop`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
-/// __This function will be deprecated in favor of [`future_into_py_with_loop`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
-/// replaced with [`future_into_py_with_loop`].__
+/// __This function was deprecated in favor of [`future_into_py_with_locals`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// replaced with [`future_into_py_with_locals`].__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -363,8 +360,8 @@ where
 /// Unlike [`future_into_py`], this function will stop the Rust future from running when
 /// the `asyncio.Future` is cancelled from Python.
 ///
-/// __This function will be deprecated in favor of [`future_into_py`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// __This function was deprecated in favor of [`future_into_py`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`future_into_py`].__
 ///
 /// # Arguments
@@ -509,12 +506,9 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
-/// Unlike [`local_future_into_py_with_loop`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
-/// __This function will be deprecated in favor of [`local_future_into_py_with_loop`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
-/// replaced with [`local_future_into_py_with_loop`].__
+/// __This function was deprecated in favor of [`local_future_into_py_with_locals`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// replaced with [`local_future_into_py_with_locals`].__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -618,8 +612,8 @@ where
 /// Unlike [`local_future_into_py`], this function will stop the Rust future from running when
 /// the `asyncio.Future` is cancelled from Python.
 ///
-/// __This function will be deprecated in favor of [`local_future_into_py`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// __This function was deprecated in favor of [`local_future_into_py`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`local_future_into_py`].__
 ///
 /// # Arguments

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -92,8 +92,7 @@ where
 
 /// Run the event loop until the given Future completes
 ///
-/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`run_forever`](`crate::run_forever`)
+/// After this function returns, the event loop can be resumed with [`run_until_complete`]
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that should run the future

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -421,6 +421,21 @@ where
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
 /// * `locals` - The task-local data for Python
@@ -867,6 +882,21 @@ where
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
 /// * `fut` - The Rust future to be converted
@@ -1054,6 +1084,21 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime and manual
 /// specification of task locals.
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - PyO3 GIL guard
@@ -1457,6 +1502,21 @@ where
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -86,7 +86,7 @@ where
     if let Some(locals) = R::get_task_locals() {
         Ok(locals)
     } else {
-        Ok(TaskLocals::new(get_running_loop(py)?).copy_context(py)?)
+        Ok(TaskLocals::with_running_loop(py)?.copy_context(py)?)
     }
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -580,7 +580,7 @@ where
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
-/// __
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -764,7 +764,7 @@ impl PyDoneCallback {
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
 /// __This function was deprecated in favor of [`future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// it became the default behaviour. In `v0.15`, any calls to this function should be
 /// replaced with [`future_into_py_with_locals`].__
 ///
 /// __In `v0.16` this function will be removed__
@@ -1345,8 +1345,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
 ///
 /// __This function was deprecated in favor of [`local_future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// it became the default behaviour. In `v0.15`, any calls to this function should be
 /// replaced with [`local_future_into_py_with_locals`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -1564,12 +1566,11 @@ where
 }
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
-/// Unlike [`local_future_into_py`], this function will stop the Rust future from running when the
-/// `asyncio.Future` is cancelled from Python.
-///
 /// __This function was deprecated in favor of [`local_future_into_py`] in `v0.15` because
 /// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`local_future_into_py`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -649,6 +649,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::generic::future_into_py_with_locals instead"
+)]
 pub fn future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     R: Runtime + ContextExt,
@@ -826,6 +830,12 @@ impl PyDoneCallback {
 ///     )
 /// }
 /// ```
+
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::generic::future_into_py_with_locals instead"
+)]
+#[allow(deprecated)]
 pub fn cancellable_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     R: Runtime + ContextExt,
@@ -1010,12 +1020,16 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::generic::future_into_py instead"
+)]
 pub fn cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
+    future_into_py::<R, F>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -1482,6 +1496,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::generic::local_future_into_py_with_locals instead"
+)]
 pub fn local_cancellable_future_into_py_with_loop<R, F>(
     event_loop: &PyAny,
     fut: F,
@@ -1599,7 +1617,7 @@ where
     R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    local_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
+    local_future_into_py_with_locals::<R, F>(py, get_current_locals::<R>(py)?, fut)
 }
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
@@ -1711,10 +1729,15 @@ where
 ///     )
 /// }
 /// ```
+///
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::generic::local_future_into_py instead"
+)]
 pub fn local_cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    local_cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
+    local_future_into_py::<R, F>(py, fut)
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -6,7 +6,7 @@ use std::{
 
 use futures::channel::oneshot;
 use pin_project_lite::pin_project;
-use pyo3::{prelude::*, PyNativeType};
+use pyo3::prelude::*;
 
 #[allow(deprecated)]
 use crate::{
@@ -725,7 +725,6 @@ struct PyDoneCallback {
 
 #[pymethods]
 impl PyDoneCallback {
-    #[call]
     pub fn __call__(&mut self, fut: &PyAny) -> PyResult<()> {
         let py = fut.py();
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -11,7 +11,7 @@ use pyo3::{prelude::*, PyNativeType};
 #[allow(deprecated)]
 use crate::{
     asyncio, call_soon_threadsafe, close, create_future, dump_err, err::RustPanic, get_event_loop,
-    get_running_loop, into_future_with_loop,
+    get_running_loop, into_future_with_locals, TaskLocals,
 };
 
 /// Generic utilities for a JoinError
@@ -27,13 +27,6 @@ pub trait Runtime {
     /// A future that completes with the result of the spawned task
     type JoinHandle: Future<Output = Result<(), Self::JoinError>> + Send;
 
-    /// Set the task local event loop for the given future
-    fn scope<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
-    where
-        F: Future<Output = R> + Send + 'static;
-    /// Get the task local event loop for the current task
-    fn get_task_event_loop(py: Python) -> Option<&PyAny>;
-
     /// Spawn a future onto this runtime's event loop
     fn spawn<F>(fut: F) -> Self::JoinHandle
     where
@@ -42,15 +35,29 @@ pub trait Runtime {
 
 /// Extension trait for async/await runtimes that support spawning local tasks
 pub trait SpawnLocalExt: Runtime {
-    /// Set the task local event loop for the given !Send future
-    fn scope_local<F, R>(event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
-    where
-        F: Future<Output = R> + 'static;
-
     /// Spawn a !Send future onto this runtime's event loop
     fn spawn_local<F>(fut: F) -> Self::JoinHandle
     where
         F: Future<Output = ()> + 'static;
+}
+
+/// Exposes the utilities necessary for using task-local data in the Runtime
+pub trait ContextExt: Runtime {
+    /// Set the task local event loop for the given future
+    fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+    where
+        F: Future<Output = R> + Send + 'static;
+
+    /// Get the task locals for the current task
+    fn get_task_locals() -> Option<TaskLocals>;
+}
+
+/// Adds the ability to scope task-local data for !Send futures
+pub trait LocalContextExt: Runtime {
+    /// Set the task local event loop for the given !Send future
+    fn scope_local<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+    where
+        F: Future<Output = R> + 'static;
 }
 
 /// Get the current event loop from either Python or Rust async task local context
@@ -60,10 +67,10 @@ pub trait SpawnLocalExt: Runtime {
 /// with the current OS thread.
 pub fn get_current_loop<R>(py: Python) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: ContextExt,
 {
-    if let Some(event_loop) = R::get_task_event_loop(py) {
-        Ok(event_loop)
+    if let Some(locals) = R::get_task_locals() {
+        Ok(locals.event_loop.into_ref(py))
     } else {
         get_running_loop(py)
     }
@@ -149,13 +156,18 @@ where
 /// ```
 pub fn run_until_complete<R, F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
-    let coro = future_into_py_with_loop::<R, _>(event_loop, async move {
-        fut.await?;
-        Ok(Python::with_gil(|py| py.None()))
-    })?;
+    let py = event_loop.py();
+    let coro = future_into_py_with_locals::<R, _>(
+        py,
+        TaskLocals::new(event_loop).copy_context(py)?,
+        async move {
+            fut.await?;
+            Ok(Python::with_gil(|py| py.None()))
+        },
+    )?;
 
     event_loop.call_method1("run_until_complete", (coro,))?;
 
@@ -237,7 +249,7 @@ where
 /// ```
 pub fn run<R, F>(py: Python, fut: F) -> PyResult<()>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
     let event_loop = asyncio(py)?.call_method0("new_event_loop")?;
@@ -254,14 +266,17 @@ fn cancelled(future: &PyAny) -> PyResult<bool> {
 }
 
 fn set_result(event_loop: &PyAny, future: &PyAny, result: PyResult<PyObject>) -> PyResult<()> {
+    let py = event_loop.py();
+    let none = py.None().into_ref(py);
+
     match result {
         Ok(val) => {
             let set_result = future.getattr("set_result")?;
-            call_soon_threadsafe(event_loop, (set_result, val))?;
+            call_soon_threadsafe(event_loop, none, (set_result, val))?;
         }
         Err(err) => {
             let set_exception = future.getattr("set_exception")?;
-            call_soon_threadsafe(event_loop, (set_exception, err))?;
+            call_soon_threadsafe(event_loop, none, (set_exception, err))?;
         }
     }
 
@@ -369,9 +384,156 @@ pub fn into_future<R>(
     awaitable: &PyAny,
 ) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
 {
-    into_future_with_loop(get_current_loop::<R>(awaitable.py())?, awaitable)
+    into_future_with_locals(
+        &TaskLocals::from_current_context::<R>(awaitable.py())?,
+        awaitable,
+    )
+}
+
+/// Convert a Rust Future into a Python awaitable with a generic runtime
+///
+/// # Arguments
+/// * `locals` - The task-local data for Python
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl MyCustomRuntime {
+/// #     async fn sleep(_: Duration) {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop(py: Python) -> Option<&PyAny> {
+/// #         unreachable!()
+/// #     }
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///     pyo3_asyncio::generic::future_into_py_with_locals::<MyCustomRuntime, _>(
+///         py,
+///         TaskLocals::from_current_context::<MyCustomRuntime>(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+/// ```
+pub fn future_into_py_with_locals<R, F>(py: Python, locals: TaskLocals, fut: F) -> PyResult<&PyAny>
+where
+    R: Runtime + ContextExt,
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+
+    let py_fut = create_future(locals.event_loop.clone().into_ref(py))?;
+    py_fut.call_method1(
+        "add_done_callback",
+        (PyDoneCallback {
+            cancel_tx: Some(cancel_tx),
+        },),
+    )?;
+
+    let future_tx1 = PyObject::from(py_fut);
+    let future_tx2 = future_tx1.clone();
+
+    R::spawn(async move {
+        let locals2 = locals.clone();
+
+        if let Err(e) = R::spawn(async move {
+            let result = R::scope(
+                locals2.clone(),
+                Cancellable::new_with_cancel_rx(fut, cancel_rx),
+            )
+            .await;
+
+            Python::with_gil(move |py| {
+                if cancelled(future_tx1.as_ref(py))
+                    .map_err(dump_err(py))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+
+                let _ = set_result(locals2.event_loop.as_ref(py), future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py));
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if cancelled(future_tx2.as_ref(py))
+                        .map_err(dump_err(py))
+                        .unwrap_or(false)
+                    {
+                        return;
+                    }
+
+                    let _ = set_result(
+                        locals.event_loop.as_ref(py),
+                        future_tx2.as_ref(py),
+                        Err(RustPanic::new_err("rust future panicked")),
+                    )
+                    .map_err(dump_err(py));
+                });
+            }
+        }
+    });
+
+    Ok(py_fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -454,56 +616,11 @@ where
 /// ```
 pub fn future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let future_rx = create_future(event_loop)?;
-    let future_tx1 = PyObject::from(future_rx);
-    let future_tx2 = future_tx1.clone();
-
-    let event_loop = PyObject::from(event_loop);
-
-    R::spawn(async move {
-        let event_loop2 = event_loop.clone();
-
-        if let Err(e) = R::spawn(async move {
-            let result = R::scope(event_loop2.clone(), fut).await;
-
-            Python::with_gil(move |py| {
-                if cancelled(future_tx1.as_ref(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
-                    .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::with_gil(move |py| {
-                    if cancelled(future_tx2.as_ref(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let _ = set_result(
-                        event_loop.as_ref(py),
-                        future_tx2.as_ref(py),
-                        Err(RustPanic::new_err("rust future panicked")),
-                    )
-                    .map_err(dump_err(py));
-                });
-            }
-        }
-    });
-
-    Ok(future_rx)
+    let py = event_loop.py();
+    future_into_py_with_locals::<R, F>(py, TaskLocals::new(event_loop).copy_context(py)?, fut)
 }
 
 pin_project! {
@@ -672,24 +789,11 @@ impl PyDoneCallback {
 /// ```
 pub fn cancellable_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    let (cancel_tx, cancel_rx) = oneshot::channel();
-
-    let py_fut = future_into_py_with_loop::<R, _>(
-        event_loop,
-        Cancellable::new_with_cancel_rx(fut, cancel_rx),
-    )?;
-
-    py_fut.call_method1(
-        "add_done_callback",
-        (PyDoneCallback {
-            cancel_tx: Some(cancel_tx),
-        },),
-    )?;
-
-    Ok(py_fut)
+    // cancellable futures became the default behaviour in 0.15
+    future_into_py_with_loop::<R, _>(event_loop, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -769,10 +873,10 @@ where
 /// ```
 pub fn future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
-    future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
+    future_into_py_with_locals::<R, F>(py, TaskLocals::from_current_context::<R>(py)?, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable with a generic runtime
@@ -859,7 +963,7 @@ where
 /// ```
 pub fn cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
     cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
@@ -947,10 +1051,176 @@ where
 #[allow(deprecated)]
 pub fn into_coroutine<R, F>(py: Python, fut: F) -> PyResult<PyObject>
 where
-    R: Runtime,
+    R: Runtime + ContextExt,
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
 {
     Ok(future_into_py_with_loop::<R, F>(get_event_loop(py), fut)?.into())
+}
+
+/// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
+///
+/// # Arguments
+/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{task::{Context, Poll}, pin::Pin, future::Future};
+/// #
+/// # use pyo3_asyncio::generic::{JoinError, SpawnLocalExt, Runtime};
+/// #
+/// # struct MyCustomJoinError;
+/// #
+/// # impl JoinError for MyCustomJoinError {
+/// #     fn is_panic(&self) -> bool {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomJoinHandle;
+/// #
+/// # impl Future for MyCustomJoinHandle {
+/// #     type Output = Result<(), MyCustomJoinError>;
+/// #
+/// #     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # struct MyCustomRuntime;
+/// #
+/// # impl MyCustomRuntime {
+/// #     async fn sleep(_: Duration) {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl Runtime for MyCustomRuntime {
+/// #     type JoinError = MyCustomJoinError;
+/// #     type JoinHandle = MyCustomJoinHandle;
+/// #     
+/// #     fn scope<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+/// #     where
+/// #         F: Future<Output = R> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #     fn get_task_event_loop(py: Python) -> Option<&PyAny> {
+/// #         unreachable!()
+/// #     }
+/// #
+/// #     fn spawn<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + Send + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// # impl SpawnLocalExt for MyCustomRuntime {
+/// #     fn scope_local<F, R>(_event_loop: PyObject, fut: F) -> Pin<Box<dyn Future<Output = R>>>
+/// #     where
+/// #         F: Future<Output = R> + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// #    
+/// #     fn spawn_local<F>(fut: F) -> Self::JoinHandle
+/// #     where
+/// #         F: Future<Output = ()> + 'static
+/// #     {
+/// #         unreachable!()
+/// #     }
+/// # }
+/// #
+/// use std::{rc::Rc, time::Duration};
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
+///     // Rc is !Send so it cannot be passed into pyo3_asyncio::generic::future_into_py
+///     let secs = Rc::new(secs);
+///
+///     pyo3_asyncio::generic::local_future_into_py_with_locals::<MyCustomRuntime, _>(
+///         py,
+///         TaskLocals::from_current_context::<MyCustomRuntime>(py)?,
+///         async move {
+///             MyCustomRuntime::sleep(Duration::from_secs(*secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+/// ```
+pub fn local_future_into_py_with_locals<R, F>(
+    py: Python,
+    locals: TaskLocals,
+    fut: F,
+) -> PyResult<&PyAny>
+where
+    R: SpawnLocalExt + LocalContextExt,
+    F: Future<Output = PyResult<PyObject>> + 'static,
+{
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+
+    let py_fut = create_future(locals.event_loop.clone().into_ref(py))?;
+    py_fut.call_method1(
+        "add_done_callback",
+        (PyDoneCallback {
+            cancel_tx: Some(cancel_tx),
+        },),
+    )?;
+
+    let future_tx1 = PyObject::from(py_fut);
+    let future_tx2 = future_tx1.clone();
+
+    R::spawn_local(async move {
+        let locals2 = locals.clone();
+
+        if let Err(e) = R::spawn_local(async move {
+            let result = R::scope_local(
+                locals2.clone(),
+                Cancellable::new_with_cancel_rx(fut, cancel_rx),
+            )
+            .await;
+
+            Python::with_gil(move |py| {
+                if cancelled(future_tx1.as_ref(py))
+                    .map_err(dump_err(py))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+
+                let _ = set_result(locals2.event_loop.as_ref(py), future_tx1.as_ref(py), result)
+                    .map_err(dump_err(py));
+            });
+        })
+        .await
+        {
+            if e.is_panic() {
+                Python::with_gil(move |py| {
+                    if cancelled(future_tx2.as_ref(py))
+                        .map_err(dump_err(py))
+                        .unwrap_or(false)
+                    {
+                        return;
+                    }
+
+                    let _ = set_result(
+                        locals.event_loop.as_ref(py),
+                        future_tx2.as_ref(py),
+                        Err(RustPanic::new_err("Rust future panicked")),
+                    )
+                    .map_err(dump_err(py));
+                });
+            }
+        }
+    });
+
+    Ok(py_fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1051,56 +1321,11 @@ where
 /// ```
 pub fn local_future_into_py_with_loop<R, F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
-    R: SpawnLocalExt,
+    R: Runtime + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let future_rx = create_future(event_loop)?;
-    let future_tx1 = PyObject::from(future_rx);
-    let future_tx2 = future_tx1.clone();
-
-    let event_loop = PyObject::from(event_loop);
-
-    R::spawn_local(async move {
-        let event_loop2 = event_loop.clone();
-
-        if let Err(e) = R::spawn_local(async move {
-            let result = R::scope_local(event_loop2.clone(), fut).await;
-
-            Python::with_gil(move |py| {
-                if cancelled(future_tx1.as_ref(py))
-                    .map_err(dump_err(py))
-                    .unwrap_or(false)
-                {
-                    return;
-                }
-
-                let _ = set_result(event_loop2.as_ref(py), future_tx1.as_ref(py), result)
-                    .map_err(dump_err(py));
-            });
-        })
-        .await
-        {
-            if e.is_panic() {
-                Python::with_gil(move |py| {
-                    if cancelled(future_tx2.as_ref(py))
-                        .map_err(dump_err(py))
-                        .unwrap_or(false)
-                    {
-                        return;
-                    }
-
-                    let _ = set_result(
-                        event_loop.as_ref(py),
-                        future_tx2.as_ref(py),
-                        Err(RustPanic::new_err("Rust future panicked")),
-                    )
-                    .map_err(dump_err(py));
-                });
-            }
-        }
-    });
-
-    Ok(future_rx)
+    let py = event_loop.py();
+    local_future_into_py_with_locals::<R, F>(py, TaskLocals::new(event_loop).copy_context(py)?, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1211,24 +1436,11 @@ pub fn local_cancellable_future_into_py_with_loop<R, F>(
     fut: F,
 ) -> PyResult<&PyAny>
 where
-    R: Runtime + SpawnLocalExt,
+    R: Runtime + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
-    let (cancel_tx, cancel_rx) = oneshot::channel();
-
-    let py_fut = local_future_into_py_with_loop::<R, _>(
-        event_loop,
-        Cancellable::new_with_cancel_rx(fut, cancel_rx),
-    )?;
-
-    py_fut.call_method1(
-        "add_done_callback",
-        (PyDoneCallback {
-            cancel_tx: Some(cancel_tx),
-        },),
-    )?;
-
-    Ok(py_fut)
+    // cancellable futures became the default in 0.15
+    local_future_into_py_with_loop::<R, F>(event_loop, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
@@ -1326,7 +1538,7 @@ where
 /// ```
 pub fn local_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: SpawnLocalExt,
+    R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     local_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)
@@ -1436,7 +1648,7 @@ where
 /// ```
 pub fn local_cancellable_future_into_py<R, F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
-    R: Runtime + SpawnLocalExt,
+    R: Runtime + ContextExt + SpawnLocalExt + LocalContextExt,
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     local_cancellable_future_into_py_with_loop::<R, F>(get_current_loop::<R>(py)?, fut)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,7 +562,7 @@ fn call_soon_threadsafe(
 /// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
 ///
 /// # Arguments
-/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `locals` - The Python event loop and context to be used for the provided awaitable
 /// * `awaitable` - The Python `awaitable` to be converted
 ///
 /// # Examples
@@ -638,6 +638,8 @@ pub fn into_future_with_locals(
 /// completion handler sends the result of this Task through a
 /// `futures::channel::oneshot::Sender<PyResult<PyObject>>` and the future returned by this function
 /// simply awaits the result through the `futures::channel::oneshot::Receiver<PyResult<PyObject>>`.
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,6 @@ use pyo3::{
     exceptions::PyKeyboardInterrupt,
     prelude::*,
     types::{PyDict, PyTuple},
-    PyNativeType,
 };
 
 static ASYNCIO: OnceCell<PyObject> = OnceCell::new();
@@ -646,7 +645,6 @@ struct PyTaskCompleter {
 
 #[pymethods]
 impl PyTaskCompleter {
-    #[call]
     #[args(task)]
     pub fn __call__(&mut self, task: &PyAny) -> PyResult<()> {
         debug_assert!(task.call_method0("done")?.extract()?);
@@ -678,7 +676,6 @@ struct PyEnsureFuture {
 
 #[pymethods]
 impl PyEnsureFuture {
-    #[call]
     pub fn __call__(&mut self) -> PyResult<()> {
         Python::with_gil(|py| {
             let task = ensure_future(py, self.awaitable.as_ref(py))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,7 +710,12 @@ fn call_soon_threadsafe(
     let py = event_loop.py();
 
     let kwargs = PyDict::new(py);
-    kwargs.set_item("context", context)?;
+
+    // Accommodate for the Python 3.6 fallback
+    // (call_soon_threadsafe does not support the context kwarg in 3.6)
+    if !context.is_none() {
+        kwargs.set_item("context", context)?;
+    }
 
     event_loop.call_method("call_soon_threadsafe", args, Some(kwargs))?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,6 +858,10 @@ pub fn into_future_with_locals(
 ///     Ok(())    
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::into_future_with_locals instead"
+)]
 pub fn into_future_with_loop(
     event_loop: &PyAny,
     awaitable: &PyAny,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,37 +18,69 @@
 //! be run on the same loop.
 //!
 //! It's not immediately clear that this would provide worthwhile performance wins either, so in the
-//! interest of keeping things simple, this crate creates and manages the Python event loop and
-//! handles the communication between separate Rust event loops.
+//! interest of getting something simple out there to facilitate these conversions, this crate
+//! handles the communication between _separate_ Python and Rust event loops.
 //!
-//! ## Python's Event Loop
+//! ## Python's Event Loop and the Main Thread
 //!
 //! Python is very picky about the threads used by the `asyncio` executor. In particular, it needs
 //! to have control over the main thread in order to handle signals like CTRL-C correctly. This
 //! means that Cargo's default test harness will no longer work since it doesn't provide a method of
 //! overriding the main function to add our event loop initialization and finalization.
 //!
-//! ## Event Loop References
+//! ## Event Loop References and ContextVars
 //!
-//! One problem that arises when interacting with Python's asyncio library is that the functions we use to get a reference to the Python event loop can only be called in certain contexts. Since PyO3 Asyncio needs to interact with Python's event loop during conversions, the context of these conversions can matter a lot.
+//! One problem that arises when interacting with Python's asyncio library is that the functions we
+//! use to get a reference to the Python event loop can only be called in certain contexts. Since
+//! PyO3 Asyncio needs to interact with Python's event loop during conversions, the context of these
+//! conversions can matter a lot.
 //!
-//! > The core conversions we've mentioned so far in this guide should insulate you from these concerns in most cases, but in the event that they don't, this section should provide you with the information you need to solve these problems.
+//! Likewise, Python's `contextvars` library can require some special treatment. Python functions
+//! and coroutines can rely on the context of outer coroutines to function correctly, so this
+//! library needs to be able to preserve `contextvars` during conversions.
+//!
+//! > The core conversions we've mentioned so far in the README should insulate you from these
+//! concerns in most cases. For the edge cases where they don't, this section should provide you
+//! with the information you need to solve these problems.
 //!
 //! ### The Main Dilemma
 //!
-//! Python programs can have many independent event loop instances throughout the lifetime of the application (`asyncio.run` for example creates its own event loop each time it's called for instance), and they can even run concurrent with other event loops. For this reason, the most correct method of obtaining a reference to the Python event loop is via `asyncio.get_running_loop`.
+//! Python programs can have many independent event loop instances throughout the lifetime of the
+//! application (`asyncio.run` for example creates its own event loop each time it's called for
+//! instance), and they can even run concurrent with other event loops. For this reason, the most
+//! correct method of obtaining a reference to the Python event loop is via
+//! `asyncio.get_running_loop`.
 //!
-//! `asyncio.get_running_loop` returns the event loop associated with the current OS thread. It can be used inside Python coroutines to spawn concurrent tasks, interact with timers, or in our case signal between Rust and Python. This is all well and good when we are operating on a Python thread, but since Rust threads are not associated with a Python event loop, `asyncio.get_running_loop` will fail when called on a Rust runtime.
+//! `asyncio.get_running_loop` returns the event loop associated with the current OS thread. It can
+//! be used inside Python coroutines to spawn concurrent tasks, interact with timers, or in our case
+//! signal between Rust and Python. This is all well and good when we are operating on a Python
+//! thread, but since Rust threads are not associated with a Python event loop,
+//! `asyncio.get_running_loop` will fail when called on a Rust runtime.
+//!
+//! `contextvars` operates in a similar way, though the current context is not always associated
+//! with the current OS thread. Different contexts can be associated with different coroutines even
+//! if they run on the same OS thread.
 //!
 //! ### The Solution
 //!
-//! A really straightforward way of dealing with this problem is to pass a reference to the associated Python event loop for every conversion. That's why in `v0.14`, we introduced a new set of conversion functions that do just that:
+//! A really straightforward way of dealing with this problem is to pass references to the
+//! associated Python event loop and context for every conversion. That's why we have a structure
+//! called `TaskLocals` and a set of conversions that accept it.
 //!
-//! - `pyo3_asyncio::into_future_with_loop` - Convert a Python awaitable into a Rust future with the given asyncio event loop.
-//! - `pyo3_asyncio::<runtime>::future_into_py_with_loop` - Convert a Rust future into a Python awaitable with the given asyncio event loop.
-//! - `pyo3_asyncio::<runtime>::local_future_into_py_with_loop` - Convert a `!Send` Rust future into a Python awaitable with the given asyncio event loop.
+//! `TaskLocals` stores the current event loop, and allows the user to copy the current Python
+//! context if necessary. The following conversions will use these references to perform the
+//! necessary conversions and restore Python context when needed:
 //!
-//! One clear disadvantage to this approach (aside from the verbose naming) is that the Rust application has to explicitly track its references to the Python event loop. In native libraries, we can't make any assumptions about the underlying event loop, so the only reliable way to make sure our conversions work properly is to store a reference to the current event loop at the callsite to use later on.
+//! - `pyo3_asyncio::into_future_with_locals` - Convert a Python awaitable into a Rust future.
+//! - `pyo3_asyncio::<runtime>::future_into_py_with_locals` - Convert a Rust future into a Python
+//! awaitable.
+//! - `pyo3_asyncio::<runtime>::local_future_into_py_with_locals` - Convert a `!Send` Rust future
+//! into a Python awaitable.
+//!
+//! One clear disadvantage to this approach is that the Rust application has to explicitly track
+//! these references. In native libraries, we can't make any assumptions about the underlying event
+//! loop, so the only reliable way to make sure our conversions work properly is to store these
+//! references at the callsite to use later on.
 //!
 //! ```rust
 //! use pyo3::{wrap_pyfunction, prelude::*};
@@ -56,24 +88,24 @@
 //! # #[cfg(feature = "tokio-runtime")]
 //! #[pyfunction]
 //! fn sleep(py: Python) -> PyResult<&PyAny> {
-//!     let current_loop = pyo3_asyncio::get_running_loop(py)?;
-//!     let loop_ref = PyObject::from(current_loop);
+//!     // Construct the task locals structure with the current running loop and context
+//!     let locals = pyo3_asyncio::TaskLocals::with_running_loop(py)?.copy_context(py)?;
 //!
 //!     // Convert the async move { } block to a Python awaitable
-//!     pyo3_asyncio::tokio::future_into_py_with_loop(current_loop, async move {
+//!     pyo3_asyncio::tokio::future_into_py_with_locals(py, locals.clone(), async move {
 //!         let py_sleep = Python::with_gil(|py| {
 //!             // Sometimes we need to call other async Python functions within
 //!             // this future. In order for this to work, we need to track the
 //!             // event loop from earlier.
-//!             pyo3_asyncio::into_future_with_loop(
-//!                 loop_ref.as_ref(py),
+//!             pyo3_asyncio::into_future_with_locals(
+//!                 &locals,
 //!                 py.import("asyncio")?.call_method1("sleep", (1,))?
 //!             )
 //!         })?;
 //!
 //!         py_sleep.await?;
 //!
-//!         Ok(Python::with_gil(|py| py.None()))
+//!         Ok(())
 //!     })
 //! }
 //!
@@ -85,18 +117,35 @@
 //! }
 //! ```
 //!
-//! > A naive solution to this tracking problem would be to cache a global reference to the asyncio event loop that all PyO3 Asyncio conversions can use. In fact this is what we did in PyO3 Asyncio `v0.13`. This works well for applications, but it soon became clear that this is not so ideal for libraries. Libraries usually have no direct control over how the event loop is managed, they're just expected to work with any event loop at any point in the application. This problem is compounded further when multiple event loops are used in the application since the global reference will only point to one.
+//! > A naive solution to this tracking problem would be to cache a global reference to the asyncio
+//! event loop that all PyO3 Asyncio conversions can use. In fact this is what we did in PyO3
+//! Asyncio `v0.13`. This works well for applications, but it soon became clear that this is not
+//! so ideal for libraries. Libraries usually have no direct control over how the event loop is
+//! managed, they're just expected to work with any event loop at any point in the application.
+//! This problem is compounded further when multiple event loops are used in the application since
+//! the global reference will only point to one.
 //!
-//! Another disadvantage to this explicit approach that is less obvious is that we can no longer call our `#[pyfunction] fn sleep` on a Rust runtime since `asyncio.get_running_loop` only works on Python threads! It's clear that we need a slightly more flexible approach.
+//! Another disadvantage to this explicit approach that is less obvious is that we can no longer
+//! call our `#[pyfunction] fn sleep` on a Rust runtime since `asyncio.get_running_loop` only works
+//! on Python threads! It's clear that we need a slightly more flexible approach.
 //!
-//! In order to detect the Python event loop at the callsite, we need something like `asyncio.get_running_loop` that works for _both Python and Rust_. In Python, `asyncio.get_running_loop` uses thread-local data to retrieve the event loop associated with the current thread. What we need in Rust is something that can retrieve the Python event loop associated with the current _task_.
+//! In order to detect the Python event loop at the callsite, we need something like
+//! `asyncio.get_running_loop` and `contextvars.copy_context` that works for _both Python and Rust_.
+//! In Python, `asyncio.get_running_loop` uses thread-local data to retrieve the event loop
+//! associated with the current thread. What we need in Rust is something that can retrieve the
+//! Python event loop and contextvars associated with the current Rust _task_.
 //!
-//! Enter `pyo3_asyncio::<runtime>::get_current_loop`. This function first checks task-local data for a Python event loop, then falls back on `asyncio.get_running_loop` if no task-local event loop is found. This way both bases are covered.
+//! Enter `pyo3_asyncio::<runtime>::get_current_locals`. This function first checks task-local data
+//! for the `TaskLocals`, then falls back on `asyncio.get_running_loop` and
+//! `contextvars.copy_context` if no task locals are found. This way both bases are
+//! covered.
 //!
-//! Now, all we need is a way to store the event loop in task-local data. Since this is a runtime-specific feature, you can find the following functions in each runtime module:
+//! Now, all we need is a way to store the `TaskLocals` for the Rust future. Since this is a
+//! runtime-specific feature, you can find the following functions in each runtime module:
 //!
-//! - `pyo3_asyncio::<runtime>::scope` - Store the event loop in task-local data when executing the given Future.
-//! - `pyo3_asyncio::<runtime>::scope_local` - Store the event loop in task-local data when executing the given `!Send` Future.
+//! - `pyo3_asyncio::<runtime>::scope` - Store the task-local data when executing the given Future.
+//! - `pyo3_asyncio::<runtime>::scope_local` - Store the task-local data when executing the given
+//! `!Send` Future.
 //!
 //! With these new functions, we can make our previous example more correct:
 //!
@@ -107,18 +156,17 @@
 //! #[pyfunction]
 //! fn sleep(py: Python) -> PyResult<&PyAny> {
 //!     // get the current event loop through task-local data
-//!     // OR `asyncio.get_running_loop`
-//!     let locals = Python::with_gil(|py| {
-//!         pyo3_asyncio::tokio::get_current_locals(py).unwrap()
-//!     });
+//!     // OR `asyncio.get_running_loop` and `contextvars.copy_context`
+//!     let locals = pyo3_asyncio::tokio::get_current_locals(py)?;
 //!
-//!     pyo3_asyncio::tokio::future_into_py_with_loop(
-//!         locals.event_loop(py),
-//!         // Store the current loop in task-local data
+//!     pyo3_asyncio::tokio::future_into_py_with_locals(
+//!         py,
+//!         locals.clone(),
+//!         // Store the current locals in task-local data
 //!         pyo3_asyncio::tokio::scope(locals.clone(), async move {
 //!             let py_sleep = Python::with_gil(|py| {
 //!                 pyo3_asyncio::into_future_with_locals(
-//!                     // Now we can get the current loop through task-local data
+//!                     // Now we can get the current locals through task-local data
 //!                     &pyo3_asyncio::tokio::get_current_locals(py)?,
 //!                     py.import("asyncio")?.call_method1("sleep", (1,))?
 //!                 )
@@ -135,18 +183,19 @@
 //! #[pyfunction]
 //! fn wrap_sleep(py: Python) -> PyResult<&PyAny> {
 //!     // get the current event loop through task-local data
-//!     // OR `asyncio.get_running_loop`
+//!     // OR `asyncio.get_running_loop` and `contextvars.copy_context`
 //!     let locals = pyo3_asyncio::tokio::get_current_locals(py)?;
 //!
-//!     pyo3_asyncio::tokio::future_into_py_with_loop(
-//!         locals.event_loop(py),
-//!         // Store the current loop in task-local data
+//!     pyo3_asyncio::tokio::future_into_py_with_locals(
+//!         py,
+//!         locals.clone(),
+//!         // Store the current locals in task-local data
 //!         pyo3_asyncio::tokio::scope(locals.clone(), async move {
 //!             let py_sleep = Python::with_gil(|py| {
 //!                 pyo3_asyncio::into_future_with_locals(
 //!                     &pyo3_asyncio::tokio::get_current_locals(py)?,
 //!                     // We can also call sleep within a Rust task since the
-//!                     // event loop is stored in task local data
+//!                     // locals are stored in task local data
 //!                     sleep(py)?
 //!                 )
 //!             })?;
@@ -167,16 +216,23 @@
 //! }
 //! ```
 //!
-//! Even though this is more correct, it's clearly not more ergonomic. That's why we introduced a new set of functions with this functionality baked in:
+//! Even though this is more correct, it's clearly not more ergonomic. That's why we introduced a
+//! set of functions with this functionality baked in:
 //!
 //! - `pyo3_asyncio::<runtime>::into_future`
-//!   > Convert a Python awaitable into a Rust future (using `pyo3_asyncio::<runtime>::get_current_loop`)
+//!   > Convert a Python awaitable into a Rust future (using
+//!   `pyo3_asyncio::<runtime>::get_current_locals`)
 //! - `pyo3_asyncio::<runtime>::future_into_py`
-//!   > Convert a Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope` to set the task-local event loop for the given Rust future)
+//!   > Convert a Rust future into a Python awaitable (using
+//!   `pyo3_asyncio::<runtime>::get_current_locals` and `pyo3_asyncio::<runtime>::scope` to set the
+//!   task-local event loop for the given Rust future)
 //! - `pyo3_asyncio::<runtime>::local_future_into_py`
-//!   > Convert a `!Send` Rust future into a Python awaitable (using `pyo3_asyncio::<runtime>::get_current_loop` and `pyo3_asyncio::<runtime>::scope_local` to set the task-local event loop for the given Rust future).
+//!   > Convert a `!Send` Rust future into a Python awaitable (using
+//!   `pyo3_asyncio::<runtime>::get_current_locals` and `pyo3_asyncio::<runtime>::scope_local` to
+//!   set the task-local event loop for the given Rust future).
 //!
-//! __These are the functions that we recommend using__. With these functions, the previous example can be rewritten to be more compact:
+//! __These are the functions that we recommend using__. With these functions, the previous example
+//! can be rewritten to be more compact:
 //!
 //! ```rust
 //! use pyo3::prelude::*;
@@ -220,25 +276,17 @@
 //! }
 //! ```
 //!
-//! ## A Note for `v0.13` Users
-//!
-//! Hey guys, I realize that these are pretty major changes for `v0.14`, and I apologize in advance for having to modify the public API so much. I hope
-//! the explanation above gives some much needed context and justification for all the breaking changes.
-//!
-//! Part of the reason why it's taken so long to push out a `v0.14` release is because I wanted to make sure we got this release right. There were a lot of issues with the `v0.13` release that I hadn't anticipated, and it's thanks to your feedback and patience that we've worked through these issues to get a more correct, more flexible version out there!
-//!
-//! This new release should address most the core issues that users have reported in the `v0.13` release, so I think we can expect more stability going forward.
-//!
-//! Also, a special thanks to [@ShadowJonathan](https://github.com/ShadowJonathan) for helping with the design and review
-//! of these changes!
-//!
-//! - [@awestlake87](https://github.com/awestlake87)
+//! > A special thanks to [@ShadowJonathan](https://github.com/ShadowJonathan) for helping with the
+//! design and review of these changes!
 //!
 //! ## Rust's Event Loop
 //!
-//! Currently only the async-std and Tokio runtimes are supported by this crate.
+//! Currently only the Async-Std and Tokio runtimes are supported by this crate. If you need support
+//! for another runtime, feel free to make a request on GitHub (or attempt to add support yourself
+//! with the [`generic`] module)!
 //!
-//! > _In the future, more runtimes may be supported for Rust._
+//! > _In the future, we may implement first class support for more Rust runtimes. Contributions are
+//! welcome as well!_
 //!
 //! ## Features
 //!
@@ -455,6 +503,11 @@ impl TaskLocals {
             event_loop: event_loop.into(),
             context: event_loop.py().None(),
         }
+    }
+
+    /// Construct TaskLocals with the event loop returned by `get_running_loop`
+    pub fn with_running_loop(py: Python) -> PyResult<Self> {
+        Ok(Self::new(get_running_loop(py)?))
     }
 
     /// Manually provide the contextvars for the current task.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio]
-//! version = "0.13"
+//! version = "0.15"
 //! features = ["attributes"]
 //! ```
 //!
@@ -264,7 +264,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio]
-//! version = "0.13"
+//! version = "0.15"
 //! features = ["async-std-runtime"]
 //! ```
 //!
@@ -277,7 +277,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio]
-//! version = "0.13"
+//! version = "0.15"
 //! features = ["tokio-runtime"]
 //! ```
 //!
@@ -290,7 +290,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3-asyncio]
-//! version = "0.13"
+//! version = "0.15"
 //! features = ["testing"]
 //! ```
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -129,6 +129,12 @@ pub fn get_current_loop(py: Python) -> PyResult<&PyAny> {
     generic::get_current_loop::<TokioRuntime>(py)
 }
 
+/// Either copy the task locals from the current task OR get the current running loop and
+/// contextvars from Python.
+pub fn get_current_locals(py: Python) -> PyResult<TaskLocals> {
+    generic::get_current_locals::<TokioRuntime>(py)
+}
+
 /// Initialize the Tokio runtime with a custom build
 pub fn init(builder: Builder) {
     *TOKIO_BUILDER.lock().unwrap() = builder
@@ -431,8 +437,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| -> PyResult<PyObject> {
-///         Ok(pyo3_asyncio::tokio::get_current_loop(py)?.into())
+///     let locals = Python::with_gil(|py| -> PyResult<_> {
+///         pyo3_asyncio::tokio::get_current_locals(py)
 ///     })?;
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -442,7 +448,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -502,8 +508,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| -> PyResult<PyObject> {
-///         Ok(pyo3_asyncio::tokio::get_current_loop(py)?.into())
+///     let locals = Python::with_gil(|py| -> PyResult<_> {
+///         pyo3_asyncio::tokio::get_current_locals(py)
 ///     })?;
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -513,7 +519,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -565,8 +571,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| {
-///         PyObject::from(pyo3_asyncio::tokio::get_current_loop(py).unwrap())
+///     let locals = Python::with_gil(|py| {
+///         pyo3_asyncio::tokio::get_current_locals(py).unwrap()
 ///     });
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -576,7 +582,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)
@@ -632,8 +638,8 @@ where
 /// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
 /// #[pyo3_asyncio::tokio::main]
 /// async fn main() -> PyResult<()> {
-///     let event_loop = Python::with_gil(|py| {
-///         PyObject::from(pyo3_asyncio::tokio::get_current_loop(py).unwrap())
+///     let locals = Python::with_gil(|py| {
+///         pyo3_asyncio::tokio::get_current_locals(py).unwrap()
 ///     });
 ///
 ///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
@@ -643,7 +649,7 @@ where
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
 ///             pyo3_asyncio::tokio::get_runtime(),  
-///             pyo3_asyncio::tokio::scope_local(event_loop, async {
+///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
 ///                     pyo3_asyncio::tokio::into_future(py_future)

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -176,20 +176,14 @@ fn multi_thread() -> Builder {
 /// # use pyo3::prelude::*;
 /// #
 /// # pyo3::prepare_freethreaded_python();
-/// # Python::with_gil(|py| {
-/// # pyo3_asyncio::with_runtime(py, || {
+/// # Python::with_gil(|py| -> PyResult<()> {
 /// # let event_loop = py.import("asyncio")?.call_method0("new_event_loop")?;
 /// pyo3_asyncio::tokio::run_until_complete(event_loop, async move {
 ///     tokio::time::sleep(Duration::from_secs(1)).await;
 ///     Ok(())
 /// })?;
 /// # Ok(())
-/// # })
-/// # .map_err(|e| {
-/// #    e.print_and_set_sys_last_vars(py);  
-/// # })
-/// # .unwrap();
-/// # });
+/// # }).unwrap();
 /// ```
 pub fn run_until_complete<F>(event_loop: &PyAny, fut: F) -> PyResult<()>
 where
@@ -229,41 +223,6 @@ where
     F: Future<Output = PyResult<()>> + Send + 'static,
 {
     generic::run::<TokioRuntime, F>(py, fut)
-}
-
-/// Convert a Rust Future into a Python awaitable
-///
-/// # Arguments
-/// * `py` - The current PyO3 GIL guard
-/// * `fut` - The Rust future to be converted
-///
-/// # Examples
-///
-/// ```
-/// use std::time::Duration;
-///
-/// use pyo3::prelude::*;
-///
-/// /// Awaitable sleep function
-/// #[pyfunction]
-/// fn sleep_for(py: Python, secs: &PyAny) -> PyResult<PyObject> {
-///     let secs = secs.extract()?;
-///     pyo3_asyncio::tokio::into_coroutine(py, async move {
-///         tokio::time::sleep(Duration::from_secs(secs)).await;
-///         Python::with_gil(|py| Ok(py.None()))
-///     })
-/// }
-/// ```
-#[deprecated(
-    since = "0.14.0",
-    note = "Use pyo3_asyncio::tokio::future_into_py instead\n    (see the [migration guide](https://github.com/awestlake87/pyo3-asyncio/#migrating-from-013-to-014) for more details)"
-)]
-#[allow(deprecated)]
-pub fn into_coroutine<F>(py: Python, fut: F) -> PyResult<PyObject>
-where
-    F: Future<Output = PyResult<PyObject>> + Send + 'static,
-{
-    generic::into_coroutine::<TokioRuntime, _>(py, fut)
 }
 
 /// Convert a Rust Future into a Python awaitable

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -301,12 +301,9 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
-/// Unlike [`future_into_py_with_loop`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
-/// __This function will be deprecated in favor of [`future_into_py_with_loop`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
-/// replaced with [`future_into_py_with_loop`].__
+/// __This function was deprecated in favor of [`future_into_py_with_locals`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// replaced with [`future_into_py_with_locals`].__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -380,8 +377,8 @@ where
 /// Unlike [`future_into_py`], this function will stop the Rust future from running when
 /// the `asyncio.Future` is cancelled from Python.
 ///
-/// __This function will be deprecated in favor of [`future_into_py`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// __This function was deprecated in favor of [`future_into_py`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`future_into_py`].__
 ///
 /// # Arguments
@@ -558,12 +555,9 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
-/// Unlike [`local_future_into_py_with_loop`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
-/// __This function will be deprecated in favor of [`local_future_into_py_with_loop`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
-/// replaced with [`local_future_into_py_with_loop`].__
+/// __This function was deprecated in favor of [`local_future_into_py_with_locals`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// replaced with [`local_future_into_py_with_locals`].__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -701,8 +695,8 @@ where
 /// Unlike [`local_future_into_py`], this function will stop the Rust future from running when
 /// the `asyncio.Future` is cancelled from Python.
 ///
-/// __This function will be deprecated in favor of [`local_future_into_py`] in `v0.15` because
-/// it will become the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// __This function was deprecated in favor of [`local_future_into_py`] in `v0.15` because
+/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`local_future_into_py`].__
 ///
 /// # Arguments

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -228,6 +228,8 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
+/// __This function will be removed in `v0.16`__
+///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
 /// * `fut` - The Rust future to be converted
@@ -302,8 +304,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// __This function was deprecated in favor of [`future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// it became the default behaviour. In `v0.15`, any calls to this function should be
 /// replaced with [`future_into_py_with_locals`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -374,12 +378,11 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
-/// Unlike [`future_into_py`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
 /// __This function was deprecated in favor of [`future_into_py`] in `v0.15` because
 /// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`future_into_py`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -415,6 +418,8 @@ where
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -556,8 +561,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// __This function was deprecated in favor of [`local_future_into_py_with_locals`] in `v0.15` because
-/// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
+/// it became the default behaviour. In `v0.15`, any calls to this function should be
 /// replaced with [`local_future_into_py_with_locals`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that the awaitable should be attached to
@@ -692,12 +699,11 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
-/// Unlike [`local_future_into_py`], this function will stop the Rust future from running when
-/// the `asyncio.Future` is cancelled from Python.
-///
 /// __This function was deprecated in favor of [`local_future_into_py`] in `v0.15` because
 /// it became the default behaviour. In `v0.15`, any calls to this function can be seamlessly
 /// replaced with [`local_future_into_py`].__
+///
+/// __This function will be removed in `v0.16`__
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -292,6 +292,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::future_into_py_with_locals instead"
+)]
 pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -332,6 +336,10 @@ where
 ///     )
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::future_into_py_with_locals instead"
+)]
 pub fn cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -399,6 +407,10 @@ where
 ///     })
 /// }
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::future_into_py instead"
+)]
 pub fn cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -463,11 +475,84 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::local_future_into_py_with_locals instead"
+)]
 pub fn local_future_into_py_with_loop<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
 {
     generic::local_future_into_py_with_loop::<TokioRuntime, _>(event_loop, fut)
+}
+
+/// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// # Arguments
+/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::{rc::Rc, time::Duration};
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable non-send sleep function
+/// #[pyfunction]
+/// fn sleep_for(py: Python, secs: u64) -> PyResult<&PyAny> {
+///     // Rc is non-send so it cannot be passed into pyo3_asyncio::tokio::future_into_py
+///     let secs = Rc::new(secs);
+///
+///     pyo3_asyncio::tokio::local_future_into_py_with_locals(
+///         py,
+///         pyo3_asyncio::tokio::get_current_locals(py)?,
+///         async move {
+///             tokio::time::sleep(Duration::from_secs(*secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+///
+/// # #[cfg(all(feature = "tokio-runtime", feature = "attributes"))]
+/// #[pyo3_asyncio::tokio::main]
+/// async fn main() -> PyResult<()> {
+///     let locals = Python::with_gil(|py| -> PyResult<_> {
+///         pyo3_asyncio::tokio::get_current_locals(py)
+///     })?;
+///
+///     // the main coroutine is running in a Send context, so we cannot use LocalSet here. Instead
+///     // we use spawn_blocking in order to use LocalSet::block_on
+///     tokio::task::spawn_blocking(move || {
+///         // LocalSet allows us to work with !Send futures within tokio. Without it, any calls to
+///         // pyo3_asyncio::tokio::local_future_into_py will panic.
+///         tokio::task::LocalSet::new().block_on(
+///             pyo3_asyncio::tokio::get_runtime(),  
+///             pyo3_asyncio::tokio::scope_local(locals, async {
+///                 Python::with_gil(|py| {
+///                     let py_future = sleep_for(py, 1)?;
+///                     pyo3_asyncio::tokio::into_future(py_future)
+///                 })?
+///                 .await?;
+///
+///                 Ok(())
+///             })
+///         )
+///     }).await.unwrap()
+/// }
+/// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
+/// # fn main() {}
+/// ```
+pub fn local_future_into_py_with_locals<F>(
+    py: Python,
+    locals: TaskLocals,
+    fut: F,
+) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + 'static,
+{
+    generic::local_future_into_py_with_locals::<TokioRuntime, _>(py, locals, fut)
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
@@ -534,6 +619,10 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::local_future_into_py_with_locals instead"
+)]
 pub fn local_cancellable_future_into_py_with_loop<'p, F>(
     event_loop: &'p PyAny,
     fut: F,
@@ -664,6 +753,10 @@ where
 /// # #[cfg(not(all(feature = "tokio-runtime", feature = "attributes")))]
 /// # fn main() {}
 /// ```
+#[deprecated(
+    since = "0.15.0",
+    note = "Use pyo3_asyncio::tokio::local_future_into_py instead"
+)]
 pub fn local_cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -161,8 +161,7 @@ fn multi_thread() -> Builder {
 ///
 /// The event loop runs until the given future is complete.
 ///
-/// After this function returns, the event loop can be resumed with either [`run_until_complete`] or
-/// [`crate::run_forever`]
+/// After this function returns, the event loop can be resumed with [`run_until_complete`]
 ///
 /// # Arguments
 /// * `event_loop` - The Python event loop that should run the future

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -306,6 +306,40 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
+/// # Arguments
+/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `fut` - The Rust future to be converted
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use pyo3::prelude::*;
+///
+/// /// Awaitable sleep function
+/// #[pyfunction]
+/// fn sleep_for<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+///     let secs = secs.extract()?;
+///     pyo3_asyncio::tokio::future_into_py_with_locals(
+///         py,
+///         pyo3_asyncio::tokio::get_current_locals(py)?,
+///         async move {
+///             tokio::time::sleep(Duration::from_secs(secs)).await;
+///             Python::with_gil(|py| Ok(py.None()))
+///         }
+///     )
+/// }
+/// ```
+pub fn future_into_py_with_locals<F>(py: Python, locals: TaskLocals, fut: F) -> PyResult<&PyAny>
+where
+    F: Future<Output = PyResult<PyObject>> + Send + 'static,
+{
+    generic::future_into_py_with_locals::<TokioRuntime, F>(py, locals, fut)
+}
+
+/// Convert a Rust Future into a Python awaitable
+///
 /// Unlike [`future_into_py_with_loop`], this function will stop the Rust future from running when
 /// the `asyncio.Future` is cancelled from Python.
 ///

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -268,8 +268,24 @@ where
 
 /// Convert a Rust Future into a Python awaitable
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
-/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `py` - PyO3 GIL guard
+/// * `locals` - The task locals for the given future
 /// * `fut` - The Rust future to be converted
 ///
 /// # Examples
@@ -346,6 +362,21 @@ where
 }
 
 /// Convert a Rust Future into a Python awaitable
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard
@@ -490,8 +521,24 @@ where
 
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
+///
 /// # Arguments
-/// * `event_loop` - The Python event loop that the awaitable should be attached to
+/// * `py` - PyO3 GIL guard
+/// * `locals` - The task locals for the given future
 /// * `fut` - The Rust future to be converted
 ///
 /// # Examples
@@ -637,6 +684,21 @@ where
 }
 
 /// Convert a `!Send` Rust Future into a Python awaitable
+///
+/// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+///
+/// Python `contextvars` are preserved when calling async Python functions within the Rust future
+/// via [`into_future`] (new behaviour in `v0.15`).
+///
+/// > Although `contextvars` are preserved for async Python functions, synchronous functions will
+/// unfortunately fail to resolve them when called within the Rust future. This is because the
+/// function is being called from a Rust thread, not inside an actual Python coroutine context.
+/// >
+/// > As a workaround, you can get the `contextvars` from the current task locals using
+/// [`get_current_locals`] and [`TaskLocals::context`](`crate::TaskLocals::context`), then wrap your
+/// synchronous function in a call to `contextvars.Context.run`. This will set the context, call the
+/// synchronous function, and restore the previous context when it returns or raises an exception.
 ///
 /// # Arguments
 /// * `py` - The current PyO3 GIL guard

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -296,6 +296,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -340,6 +341,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn cancellable_future_into_py_with_loop<F>(event_loop: &PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -411,6 +413,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::future_into_py instead"
 )]
+#[allow(deprecated)]
 pub fn cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + Send + 'static,
@@ -479,6 +482,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::local_future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn local_future_into_py_with_loop<'p, F>(event_loop: &'p PyAny, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,
@@ -623,6 +627,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::local_future_into_py_with_locals instead"
 )]
+#[allow(deprecated)]
 pub fn local_cancellable_future_into_py_with_loop<'p, F>(
     event_loop: &'p PyAny,
     fut: F,
@@ -757,6 +762,7 @@ where
     since = "0.15.0",
     note = "Use pyo3_asyncio::tokio::local_future_into_py instead"
 )]
+#[allow(deprecated)]
 pub fn local_cancellable_future_into_py<F>(py: Python, fut: F) -> PyResult<&PyAny>
 where
     F: Future<Output = PyResult<PyObject>> + 'static,


### PR DESCRIPTION
Consolidating changes from #52 and #54 (maybe #43 as well) to prepare for release 0.15

TODO:
- [x] Add fallback for `contextvars` in Python 3.6
- [x] Change `TaskLocals` from `#[non_exhaustive]` to private fields with public accessors
- [x] Deprecate `*_with_loop` variants in favor of `*_with_locals`
- [x] Deprecate `cancellable_*` variants
- [x] ? Merge in #43 and update `*_with_locals` variants to have generic returns
- [x] Remove 0.14 deprecations
- [x] Docs
  - [x] Include `contextvars` in discussion around Event Loop References
  - [x] Document limitation around task locals and synchronous python functions called from a Rust thread
  - [x] Ensure that docs mention that cancellable futures are now the default behaviour
  - [x] Document that `cancellable_*` and `*_with_loop` variants will be removed in `0.16`
  - [x] `v0.14` -> `v0.15` migration guide (`*_with_loop` deprecation and generic returns)
  - [x] Open PyO3 guide PR for 0.15 changes if necessary
    - At a glance, I believe it's not necessary this time. The only changes I could see were simplifying `Ok(Python::with_gil(|py| py.None()))` to `Ok(())`.
  - [x] Full review
    - I'll do a full review / link check once I merge it into master and see the API docs on GitHub pages