### PR TITLE
Use version 0.15 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Here we initialize the runtime, import Python's `asyncio` library and run the gi
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.14" }
-pyo3-asyncio = { version = "0.14", features = ["attributes", "async-std-runtime"] }
+pyo3 = { version = "0.15" }
+pyo3-asyncio = { version = "0.15", features = ["attributes", "async-std-runtime"] }
 async-std = "1.9"
 ```
 
@@ -75,8 +75,8 @@ attribute.
 ```toml
 # Cargo.toml dependencies
 [dependencies]
-pyo3 = { version = "0.14" }
-pyo3-asyncio = { version = "0.14", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.15" }
+pyo3-asyncio = { version = "0.15", features = ["attributes", "tokio-runtime"] }
 tokio = "1.9"
 ```
 
@@ -118,16 +118,16 @@ Make your project depend on `pyo3` with the `extension-module` feature enabled a
 For `async-std`:
 ```toml
 [dependencies]
-pyo3 = { version = "0.14", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.14", features = ["async-std-runtime"] }
+pyo3 = { version = "0.15", features = ["extension-module"] }
+pyo3-asyncio = { version = "0.15", features = ["async-std-runtime"] }
 async-std = "1.9"
 ```
 
 For `tokio`:
 ```toml
 [dependencies]
-pyo3 = { version = "0.14", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.14", features = ["tokio-runtime"] }
+pyo3 = { version = "0.15", features = ["extension-module"] }
+pyo3-asyncio = { version = "0.15", features = ["tokio-runtime"] }
 tokio = "1.9"
 ```
 
@@ -418,8 +418,8 @@ name = "my_async_module"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.14", features = ["extension-module"] }
-pyo3-asyncio = { version = "0.14", features = ["tokio-runtime"] }
+pyo3 = { version = "0.15", features = ["extension-module"] }
+pyo3-asyncio = { version = "0.15", features = ["tokio-runtime"] }
 async-std = "1.9"
 tokio = "1.9"
 ```
@@ -478,8 +478,8 @@ event loop before we can install the `uvloop` policy.
 ```toml
 [dependencies]
 async-std = "1.9"
-pyo3 = "0.14"
-pyo3-asyncio = { version = "0.14", features = ["async-std-runtime"] }
+pyo3 = "0.15"
+pyo3-asyncio = { version = "0.15", features = ["async-std-runtime"] }
 ```
 
 ```rust no_run


### PR DESCRIPTION
Some of the example code does no longer compile with py03-asyncio 0.14.
Therefore use the latest version for the README.md to fix that.