### PR TITLE
Upgrade pyo3 to 0.17 and bump pyo3_asyncio version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install black==19.10b0
+      - run: pip install black==22.8.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -110,6 +110,7 @@ jobs:
                 python-architecture: "x64",
                 rust-target: "x86_64-unknown-linux-gnu",
               }
+            msrv: "nightly"
             extra_features: "nightly"
 
     steps:
@@ -133,6 +134,15 @@ jobs:
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
+      - if: matrix.msrv == 'MSRV'
+        name: Prepare minimal package versions (MSRV only)
+        run: |
+          set -x
+          cargo update -p tokio --precise 1.13.1
+          cargo update -p indexmap --precise 1.6.2
+          cargo update -p parking_lot:0.12.1 --precise 0.11.2
+          cargo update -p async-global-executor --precise 2.2.0
+
       - name: Build (no features)
         run: cargo build --no-default-features --verbose --target ${{ matrix.platform.rust-target }}
 
@@ -144,6 +154,14 @@ jobs:
         name: Install pyo3-asyncio test dependencies
         run: |
           python -m pip install -U uvloop
+
+      - if: matrix.msrv != 'MSRV'
+        name: Test
+        run: cargo test --all-features
+
+      - if: matrix.msrv == 'MSRV'
+        name: Test (MSRV, --no-default-features)
+        run: cargo test --no-default-features --features tokio,async-std-runtime,unstable-streams
 
     env:
       RUST_BACKTRACE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio"
 description = "PyO3 utilities for Python's Asyncio library"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]
@@ -106,14 +106,14 @@ required-features = ["tokio-runtime", "testing"]
 async-channel = { version = "1.6", optional = true }
 clap = { version = "3.1.5", optional = true }
 futures = "0.3"
-inventory = { version = "0.2", optional = true }
+inventory = { version = "0.3", optional = true }
 once_cell = "1.5"
 pin-project-lite = "0.2"
-pyo3 = "0.16"
-pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.16.0", optional = true }
+pyo3 = "0.17"
+pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.17.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.16", features = ["macros"] }
+pyo3 = { version = "0.17", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.10"
@@ -121,6 +121,6 @@ features = ["unstable"]
 optional = true
 
 [dependencies.tokio]
-version = "1.13" 
+version = "1.13"
 features = ["full"]
 optional = true

--- a/pyo3-asyncio-macros/Cargo.toml
+++ b/pyo3-asyncio-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio-macros"
 description = "Proc Macro Attributes for PyO3 Asyncio"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "../README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]

--- a/pytests/common/mod.rs
+++ b/pytests/common/mod.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3_asyncio::TaskLocals;
 
 pub(super) const TEST_MOD: &'static str = r#"
-import asyncio 
+import asyncio
 
 async def py_sleep(duration):
     await asyncio.sleep(duration)

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -9,7 +9,6 @@ use std::{
 use async_std::task;
 use pyo3::{
     prelude::*,
-    proc_macro::pymodule,
     types::{IntoPyDict, PyType},
     wrap_pyfunction, wrap_pymodule,
 };
@@ -174,12 +173,12 @@ async fn test_cancel() -> PyResult<()> {
 
 #[cfg(feature = "unstable-streams")]
 const ASYNC_STD_TEST_MOD: &str = r#"
-import asyncio 
+import asyncio
 
 async def gen():
     for i in range(10):
         await asyncio.sleep(0.1)
-        yield i        
+        yield i
 "#;
 
 #[cfg(feature = "unstable-streams")]
@@ -257,15 +256,15 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 #[pymodule]
 fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
-    #[pyfunction]
-    fn sleep(py: Python) -> PyResult<&PyAny> {
+    #[pyfunction(name = "sleep")]
+    fn sleep_(py: Python) -> PyResult<&PyAny> {
         pyo3_asyncio::async_std::future_into_py(py, async move {
             async_std::task::sleep(Duration::from_millis(500)).await;
             Ok(())
         })
     }
 
-    m.add_function(wrap_pyfunction!(sleep, m)?)?;
+    m.add_function(wrap_pyfunction!(sleep_, m)?)?;
 
     Ok(())
 }

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -6,7 +6,6 @@ use std::{
 
 use pyo3::{
     prelude::*,
-    proc_macro::pymodule,
     types::{IntoPyDict, PyType},
     wrap_pyfunction, wrap_pymodule,
 };
@@ -229,15 +228,15 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 #[pymodule]
 fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
-    #[pyfunction]
-    fn sleep(py: Python) -> PyResult<&PyAny> {
+    #[pyfunction(name = "sleep")]
+    fn sleep_(py: Python) -> PyResult<&PyAny> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
             tokio::time::sleep(Duration::from_millis(500)).await;
             Ok(())
         })
     }
 
-    m.add_function(wrap_pyfunction!(sleep, m)?)?;
+    m.add_function(wrap_pyfunction!(sleep_, m)?)?;
 
     Ok(())
 }
@@ -293,12 +292,12 @@ fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
 
 #[cfg(feature = "unstable-streams")]
 const TOKIO_TEST_MOD: &str = r#"
-import asyncio 
+import asyncio
 
 async def gen():
     for i in range(10):
         await asyncio.sleep(0.1)
-        yield i        
+        yield i
 "#;
 
 #[cfg(feature = "unstable-streams")]

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -210,7 +210,7 @@ where
 ///             Ok(())
 ///         })
 ///         .map_err(|e| {
-///             e.print_and_set_sys_last_vars(py);  
+///             e.print_and_set_sys_last_vars(py);
 ///         })
 ///         .unwrap();
 ///     })
@@ -497,7 +497,7 @@ where
 ///         )
 ///     })?
 ///     .await?;
-///     Ok(())    
+///     Ok(())
 /// }
 /// ```
 pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
@@ -524,7 +524,7 @@ pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -537,7 +537,7 @@ pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::async_std::into_stream_v1(test_mod.call_method0("gen")?)
 /// })?;
 ///
@@ -581,7 +581,7 @@ pub fn into_stream_v1<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -594,7 +594,7 @@ pub fn into_stream_v1<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::async_std::into_stream_with_locals_v1(
 ///         pyo3_asyncio::async_std::get_current_locals(py)?,
 ///         test_mod.call_method0("gen")?
@@ -642,7 +642,7 @@ pub fn into_stream_with_locals_v1<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -655,7 +655,7 @@ pub fn into_stream_with_locals_v1<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::async_std::into_stream_with_locals_v2(
 ///         pyo3_asyncio::async_std::get_current_locals(py)?,
 ///         test_mod.call_method0("gen")?
@@ -702,7 +702,7 @@ pub fn into_stream_with_locals_v2<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -715,7 +715,7 @@ pub fn into_stream_with_locals_v2<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::async_std::into_stream_v2(test_mod.call_method0("gen")?)
 /// })?;
 ///

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -160,7 +160,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -261,7 +261,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -285,7 +285,7 @@ where
 ///             Ok(())
 ///         })
 ///         .map_err(|e| {
-///             e.print_and_set_sys_last_vars(py);  
+///             e.print_and_set_sys_last_vars(py);
 ///         })
 ///         .unwrap();
 ///     })
@@ -387,7 +387,7 @@ fn set_result(event_loop: &PyAny, future: &PyAny, result: PyResult<PyObject>) ->
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -427,7 +427,7 @@ fn set_result(event_loop: &PyAny, future: &PyAny, result: PyResult<PyObject>) ->
 ///         )
 ///     })?
 ///     .await?;
-///     Ok(())    
+///     Ok(())
 /// }
 /// ```
 pub fn into_future<R>(
@@ -509,7 +509,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -763,7 +763,7 @@ impl PyDoneCallback {
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -869,7 +869,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1062,7 +1062,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1168,7 +1168,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1189,7 +1189,7 @@ where
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
@@ -1200,7 +1200,7 @@ where
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::generic::into_stream_with_locals_v1::<MyCustomRuntime>(
 ///         pyo3_asyncio::generic::get_current_locals::<MyCustomRuntime>(py)?,
 ///         test_mod.call_method0("gen")?
@@ -1312,7 +1312,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1333,7 +1333,7 @@ where
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
@@ -1344,7 +1344,7 @@ where
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::generic::into_stream_v1::<MyCustomRuntime>(test_mod.call_method0("gen")?)
 /// })?;
 ///
@@ -1456,7 +1456,7 @@ async def forward(gen, sender):
 
         if asyncio.iscoroutine(should_continue):
             should_continue = await should_continue
-    
+
         if should_continue:
             continue
         else:
@@ -1516,7 +1516,7 @@ async def forward(gen, sender):
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1537,7 +1537,7 @@ async def forward(gen, sender):
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
@@ -1548,7 +1548,7 @@ async def forward(gen, sender):
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::generic::into_stream_with_locals_v2::<MyCustomRuntime>(
 ///         pyo3_asyncio::generic::get_current_locals::<MyCustomRuntime>(py)?,
 ///         test_mod.call_method0("gen")?
@@ -1661,7 +1661,7 @@ where
 /// #     }
 /// # }
 /// #
-/// # impl ContextExt for MyCustomRuntime {    
+/// # impl ContextExt for MyCustomRuntime {
 /// #     fn scope<F, R>(locals: TaskLocals, fut: F) -> Pin<Box<dyn Future<Output = R> + Send>>
 /// #     where
 /// #         F: Future<Output = R> + Send + 'static
@@ -1682,7 +1682,7 @@ where
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # async fn test_async_gen() -> PyResult<()> {
@@ -1693,7 +1693,7 @@ where
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::generic::into_stream_v2::<MyCustomRuntime>(test_mod.call_method0("gen")?)
 /// })?;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,6 @@ impl PyTaskCompleter {
     #[args(task)]
     pub fn __call__(&mut self, task: &PyAny) -> PyResult<()> {
         debug_assert!(task.call_method0("done")?.extract()?);
-
         let result = match task.call_method0("result") {
             Ok(val) => Ok(val.into()),
             Err(e) => Err(e),
@@ -623,7 +622,7 @@ fn call_soon_threadsafe(
 ///         )
 ///     })?
 ///     .await?;
-///     Ok(())    
+///     Ok(())
 /// }
 /// ```
 pub fn into_future_with_locals(

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -227,7 +227,7 @@ where
 ///             Ok(())
 ///         })
 ///         .map_err(|e| {
-///             e.print_and_set_sys_last_vars(py);  
+///             e.print_and_set_sys_last_vars(py);
 ///         })
 ///         .unwrap();
 ///     })
@@ -396,7 +396,7 @@ where
 ///         // LocalSet allows us to work with !Send futures within tokio. Without it, any calls to
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
-///             pyo3_asyncio::tokio::get_runtime(),  
+///             pyo3_asyncio::tokio::get_runtime(),
 ///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
@@ -476,7 +476,7 @@ where
 ///         // LocalSet allows us to work with !Send futures within tokio. Without it, any calls to
 ///         // pyo3_asyncio::tokio::local_future_into_py will panic.
 ///         tokio::task::LocalSet::new().block_on(
-///             pyo3_asyncio::tokio::get_runtime(),  
+///             pyo3_asyncio::tokio::get_runtime(),
 ///             pyo3_asyncio::tokio::scope_local(locals, async {
 ///                 Python::with_gil(|py| {
 ///                     let py_future = sleep_for(py, 1)?;
@@ -545,7 +545,7 @@ where
 ///         )
 ///     })?
 ///     .await?;
-///     Ok(())    
+///     Ok(())
 /// }
 /// ```
 pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<PyObject>> + Send> {
@@ -573,7 +573,7 @@ pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -586,7 +586,7 @@ pub fn into_future(awaitable: &PyAny) -> PyResult<impl Future<Output = PyResult<
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::tokio::into_stream_with_locals_v1(
 ///         pyo3_asyncio::tokio::get_current_locals(py)?,
 ///         test_mod.call_method0("gen")?
@@ -633,7 +633,7 @@ pub fn into_stream_with_locals_v1<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -646,7 +646,7 @@ pub fn into_stream_with_locals_v1<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::tokio::into_stream_v1(test_mod.call_method0("gen")?)
 /// })?;
 ///
@@ -690,7 +690,7 @@ pub fn into_stream_v1<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -703,7 +703,7 @@ pub fn into_stream_v1<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::tokio::into_stream_with_locals_v2(
 ///         pyo3_asyncio::tokio::get_current_locals(py)?,
 ///         test_mod.call_method0("gen")?
@@ -750,7 +750,7 @@ pub fn into_stream_with_locals_v2<'p>(
 /// async def gen():
 ///     for i in range(10):
 ///         await asyncio.sleep(0.1)
-///         yield i        
+///         yield i
 /// "#;
 ///
 /// # #[cfg(all(feature = "unstable-streams", feature = "attributes"))]
@@ -763,7 +763,7 @@ pub fn into_stream_with_locals_v2<'p>(
 ///         "test_rust_coroutine/test_mod.py",
 ///         "test_mod",
 ///     )?;
-///   
+///
 ///     pyo3_asyncio::tokio::into_stream_v2(test_mod.call_method0("gen")?)
 /// })?;
 ///


### PR DESCRIPTION
Done:
 - upgrade pyo3 dependency to 0.17
 - upgrade inventory to 0.3 (to match pyo3)
 - fixed tests
 - fixed CI to deal with messy MSRV requirements with inventory upgrade (copied and modified from pyo3's handling)
 - added running tests to CI (if there was a reason these weren't run previously, i can remove them as well)
 - removed a bunch of end of line whitespace (simply because my editor did it automatically and I was lazy to undo it, if i should remove them I can)
