### PR TITLE
tokio_test: add panic message into exception string

### DIFF
--- a/pyo3-asyncio-macros/src/lib.rs
+++ b/pyo3-asyncio-macros/src/lib.rs
@@ -250,7 +250,8 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         Ok(result) => result,
                         Err(e) => {
                             assert!(e.is_panic());
-                            Err(pyo3::exceptions::PyException::new_err("rust future panicked"))
+                            let panic_message = get_panic_message(&e.into_panic());
+                            Err(pyo3::exceptions::PyException::new_err(format!("rust future panicked: {}", panic_message)))
                         }
                     }
                 })
@@ -265,7 +266,8 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         Ok(result) => result,
                         Err(e) => {
                             assert!(e.is_panic());
-                            Err(pyo3::exceptions::PyException::new_err("rust future panicked"))
+                            let panic_message = get_panic_message(&e.into_panic());
+                            Err(pyo3::exceptions::PyException::new_err(format!("rust future panicked: {}", panic_message)))
                         }
                     }
                 })
@@ -305,4 +307,14 @@ pub fn tokio_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     result.into()
+}
+
+fn get_panic_message(any: &dyn Any) -> &str {
+    if let Ok(str_slice) = any.downcast_ref::<&str>() {
+        str_slice
+    } else if let Ok(string) = any.downcast_ref::<String>() {
+        &string
+    } else {
+        "unknown error"
+    }
 }

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -48,6 +48,9 @@ impl JoinError for AsyncStdJoinErr {
     fn is_panic(&self) -> bool {
         true
     }
+    fn into_panic(self) -> Box<dyn Any + Send + 'static> {
+        self.0
+    }
 }
 
 async_std::task_local! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,8 +363,9 @@ pub mod err;
 pub mod generic;
 
 #[pymodule]
-fn pyo3_asyncio(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("RustPanic", py.get_type::<err::exceptions::RustPanic>())?;
+fn pyo3_asyncio(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("RustPanic", py.get_type::<err::RustPanic>())?;
+    Ok(())
 }
 
 /// Test README

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,11 @@ pub mod err;
 
 pub mod generic;
 
+#[pymodule]
+fn pyo3_asyncio(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("RustPanic", py.get_type::<err::exceptions::RustPanic>())?;
+}
+
 /// Test README
 #[doc(hidden)]
 pub mod doc_test {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -72,6 +72,9 @@ impl generic::JoinError for task::JoinError {
     fn is_panic(&self) -> bool {
         task::JoinError::is_panic(self)
     }
+    fn into_panic(self) -> Box<dyn std::any::Any + Send + 'static> {
+        task::JoinError::into_panic(self)
+    }
 }
 
 struct TokioRuntime;


### PR DESCRIPTION
Add future's panic message into python exception string.
I didn't test this.  I don't know if `tokio_test` macro is covered by y'alls tests.