### PR TITLE
Bump and migrate pyo3 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio"
 description = "PyO3 utilities for Python's Asyncio library"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]
@@ -116,11 +116,11 @@ futures = "0.3"
 inventory = { version = "0.3", optional = true }
 once_cell = "1.14"
 pin-project-lite = "0.2"
-pyo3 = "0.20"
-pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.20.0", optional = true }
+pyo3 = "0.21"
+pyo3-asyncio-macros = { path = "pyo3-asyncio-macros", version = "=0.21.0", optional = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.20", features = ["macros"] }
+pyo3 = { version = "0.21", features = ["macros"] }
 
 [dependencies.async-std]
 version = "1.12"

--- a/Code-of-Conduct.md
+++ b/Code-of-Conduct.md
@@ -11,7 +11,7 @@ appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behaviour that contributes to creating a positive environment
+Examples of behavior that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -20,7 +20,7 @@ include:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
-Examples of unacceptable behaviour by participants include:
+Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
   advances
@@ -34,13 +34,13 @@ Examples of unacceptable behaviour by participants include:
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behaviour and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behaviour.
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviours that they deem inappropriate,
+permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -54,7 +54,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/Code-of-Conduct.md
+++ b/Code-of-Conduct.md
@@ -11,7 +11,7 @@ appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
+Examples of behaviour that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -20,7 +20,7 @@ include:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behaviour by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
   advances
@@ -34,13 +34,13 @@ Examples of unacceptable behavior by participants include:
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+permanently any contributor for other behaviours that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -54,7 +54,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported by contacting the project team. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ RuntimeError: no running event loop
 ```
 
 What's happening here is that we are calling `rust_sleep` _before_ the future is
-actually running on the event loop created by `asyncio.run`. This is counter-intuitive, but expected behaviour, and unfortunately there doesn't seem to be a good way of solving this problem within PyO3 Asyncio itself.
+actually running on the event loop created by `asyncio.run`. This is counter-intuitive, but expected behavior, and unfortunately there doesn't seem to be a good way of solving this problem within PyO3 Asyncio itself.
 
 However, we can make this example work with a simple workaround:
 
@@ -541,7 +541,7 @@ fn main() -> PyResult<()> {
 
 So what's changed from `v0.13` to `v0.14`?
 
-Well, a lot actually. There were some pretty major flaws in the initialization behaviour of `v0.13`. While it would have been nicer to address these issues without changing the public API, I decided it'd be better to break some of the old API rather than completely change the underlying behaviour of the existing functions. I realize this is going to be a bit of a headache, so hopefully this section will help you through it.
+Well, a lot actually. There were some pretty major flaws in the initialization behavior of `v0.13`. While it would have been nicer to address these issues without changing the public API, I decided it'd be better to break some of the old API rather than completely change the underlying behavior of the existing functions. I realize this is going to be a bit of a headache, so hopefully this section will help you through it.
 
 To make things a bit easier, I decided to keep most of the old API alongside the new one (with some deprecation warnings to encourage users to move away from it). It should be possible to use the `v0.13` API alongside the newer `v0.14` API, which should allow you to upgrade your application piecemeal rather than all at once.
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ RuntimeError: no running event loop
 ```
 
 What's happening here is that we are calling `rust_sleep` _before_ the future is
-actually running on the event loop created by `asyncio.run`. This is counter-intuitive, but expected behavior, and unfortunately there doesn't seem to be a good way of solving this problem within PyO3 Asyncio itself.
+actually running on the event loop created by `asyncio.run`. This is counter-intuitive, but expected behaviour, and unfortunately there doesn't seem to be a good way of solving this problem within PyO3 Asyncio itself.
 
 However, we can make this example work with a simple workaround:
 
@@ -541,7 +541,7 @@ fn main() -> PyResult<()> {
 
 So what's changed from `v0.13` to `v0.14`?
 
-Well, a lot actually. There were some pretty major flaws in the initialization behavior of `v0.13`. While it would have been nicer to address these issues without changing the public API, I decided it'd be better to break some of the old API rather than completely change the underlying behavior of the existing functions. I realize this is going to be a bit of a headache, so hopefully this section will help you through it.
+Well, a lot actually. There were some pretty major flaws in the initialization behaviour of `v0.13`. While it would have been nicer to address these issues without changing the public API, I decided it'd be better to break some of the old API rather than completely change the underlying behaviour of the existing functions. I realize this is going to be a bit of a headache, so hopefully this section will help you through it.
 
 To make things a bit easier, I decided to keep most of the old API alongside the new one (with some deprecation warnings to encourage users to move away from it). It should be possible to use the `v0.13` API alongside the newer `v0.14` API, which should allow you to upgrade your application piecemeal rather than all at once.
 
@@ -569,7 +569,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
 ### Upgrading Your Code to 0.14
 
 1. Fix PyO3 0.14 initialization.
-   - PyO3 0.14 feature gated its automatic initialization behavior behind "auto-initialize". You can either enable the "auto-initialize" behavior in your project or add a call to `pyo3::prepare_freethreaded_python()` to the start of your program.
+   - PyO3 0.14 feature gated its automatic initialization behaviour behind "auto-initialize". You can either enable the "auto-initialize" behaviour in your project or add a call to `pyo3::prepare_freethreaded_python()` to the start of your program.
    - If you're using the `#[pyo3_asyncio::<runtime>::main]` proc macro attributes, then you can skip this step. `#[pyo3_asyncio::<runtime>::main]` will call `pyo3::prepare_freethreaded_python()` at the start regardless of your project's "auto-initialize" feature.
 2. Fix the tokio initialization.
 
@@ -646,7 +646,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
 There have been a few changes to the API in order to support proper cancellation from Python and the `contextvars` module.
 
 - Any instance of `cancellable_future_into_py` and `local_cancellable_future_into_py` conversions can be replaced with their`future_into_py` and `local_future_into_py` counterparts.
-  > Cancellation support became the default behavior in 0.15.
+  > Cancellation support became the default behaviour in 0.15.
 - Instances of `*_with_loop` conversions should be replaced with the newer `*_with_locals` conversions.
 
   ```rust no_run

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ use pyo3::prelude::*;
 #[pyo3_asyncio::async_std::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import("asyncio")?;
+        let asyncio = py.import_bound("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_asyncio::async_std::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
@@ -95,7 +95,7 @@ use pyo3::prelude::*;
 #[pyo3_asyncio::tokio::main]
 async fn main() -> PyResult<()> {
     let fut = Python::with_gil(|py| {
-        let asyncio = py.import("asyncio")?;
+        let asyncio = py.import_bound("asyncio")?;
         // convert asyncio.sleep into a Rust Future
         pyo3_asyncio::tokio::into_future(asyncio.call_method1("sleep", (1.into_py(py),))?)
     })?;
@@ -237,7 +237,7 @@ use pyo3::prelude::*;
 async fn main() -> PyResult<()> {
     let future = Python::with_gil(|py| -> PyResult<_> {
         // import the module containing the py_sleep function
-        let example = py.import("example")?;
+        let example = py.import_bound("example")?;
 
         // calling the py_sleep method like a normal function
         // returns a coroutine
@@ -356,7 +356,7 @@ async fn main() -> PyResult<()> {
     // PyO3 is initialized - Ready to go
 
     let fut = Python::with_gil(|py| -> PyResult<_> {
-        let asyncio = py.import("asyncio")?;
+        let asyncio = py.import_bound("asyncio")?;
 
         // convert asyncio.sleep into a Rust Future
         pyo3_asyncio::async_std::into_future(
@@ -504,7 +504,7 @@ fn main() -> PyResult<()> {
     pyo3::prepare_freethreaded_python();
 
     Python::with_gil(|py| {
-        let uvloop = py.import("uvloop")?;
+        let uvloop = py.import_bound("uvloop")?;
         uvloop.call_method0("install")?;
 
         // store a reference for the assertion
@@ -514,7 +514,7 @@ fn main() -> PyResult<()> {
             // verify that we are on a uvloop.Loop
             Python::with_gil(|py| -> PyResult<()> {
                 assert!(uvloop
-                    .as_ref(py)
+                    .bind(py)
                     .getattr("Loop")?
                     .downcast::<PyType>()
                     .unwrap()
@@ -569,7 +569,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
 ### Upgrading Your Code to 0.14
 
 1. Fix PyO3 0.14 initialization.
-   - PyO3 0.14 feature gated its automatic initialization behaviour behind "auto-initialize". You can either enable the "auto-initialize" behaviour in your project or add a call to `pyo3::prepare_freethreaded_python()` to the start of your program.
+   - PyO3 0.14 feature gated its automatic initialization behavior behind "auto-initialize". You can either enable the "auto-initialize" behavior in your project or add a call to `pyo3::prepare_freethreaded_python()` to the start of your program.
    - If you're using the `#[pyo3_asyncio::<runtime>::main]` proc macro attributes, then you can skip this step. `#[pyo3_asyncio::<runtime>::main]` will call `pyo3::prepare_freethreaded_python()` at the start regardless of your project's "auto-initialize" feature.
 2. Fix the tokio initialization.
 
@@ -601,7 +601,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
        pyo3::prepare_freethreaded_python();
 
        Python::with_gil(|py| {
-           let asyncio = py.import("asyncio")?;
+           let asyncio = py.import_bound("asyncio")?;
 
            let event_loop = asyncio.call_method0("new_event_loop")?;
            asyncio.call_method1("set_event_loop", (event_loop,))?;
@@ -614,11 +614,11 @@ To make things a bit easier, I decided to keep most of the old API alongside the
                // Stop the event loop manually
                Python::with_gil(|py| {
                    event_loop_hdl
-                       .as_ref(py)
+                       .bind(py)
                        .call_method1(
                            "call_soon_threadsafe",
                            (event_loop_hdl
-                               .as_ref(py)
+                               .bind(py)
                                .getattr("stop")
                                .unwrap(),),
                        )
@@ -646,7 +646,7 @@ To make things a bit easier, I decided to keep most of the old API alongside the
 There have been a few changes to the API in order to support proper cancellation from Python and the `contextvars` module.
 
 - Any instance of `cancellable_future_into_py` and `local_cancellable_future_into_py` conversions can be replaced with their`future_into_py` and `local_future_into_py` counterparts.
-  > Cancellation support became the default behaviour in 0.15.
+  > Cancellation support became the default behavior in 0.15.
 - Instances of `*_with_loop` conversions should be replaced with the newer `*_with_locals` conversions.
 
   ```rust no_run

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Export an async function that makes use of `async-std`:
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn rust_sleep(py: Python) -> PyResult<&PyAny> {
+fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
     pyo3_asyncio::async_std::future_into_py(py, async {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
@@ -173,7 +173,7 @@ If you want to use `tokio` instead, here's what your module should look like:
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn rust_sleep(py: Python) -> PyResult<&PyAny> {
+fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
     pyo3_asyncio::tokio::future_into_py(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())
@@ -289,7 +289,7 @@ async fn rust_sleep() {
 }
 
 #[pyfunction]
-fn call_rust_sleep(py: Python) -> PyResult<&PyAny> {
+fn call_rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
     pyo3_asyncio::async_std::future_into_py(py, async move {
         rust_sleep().await;
         Ok(())
@@ -443,7 +443,7 @@ tokio = "1.9"
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn rust_sleep(py: Python) -> PyResult<&PyAny> {
+fn rust_sleep(py: Python) -> PyResult<Bound<PyAny>> {
     pyo3_asyncio::tokio::future_into_py(py, async {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok(())

--- a/pyo3-asyncio-macros/Cargo.toml
+++ b/pyo3-asyncio-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-asyncio-macros"
 description = "Proc Macro Attributes for PyO3 Asyncio"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Andrew J Westlake <awestlake87@yahoo.com>"]
 readme = "../README.md"
 keywords = ["pyo3", "python", "ffi", "async", "asyncio"]

--- a/pytests/test_async_std_asyncio.rs
+++ b/pytests/test_async_std_asyncio.rs
@@ -18,7 +18,7 @@ use pyo3_asyncio::TaskLocals;
 use futures::{StreamExt, TryStreamExt};
 
 #[pyfunction]
-fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+fn sleep<'p>(py: Python<'p>, secs: Bound<PyAny>) -> PyResult<Bound<PyAny>> {
     let secs = secs.extract()?;
 
     pyo3_asyncio::async_std::future_into_py(py, async move {
@@ -258,7 +258,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction(name = "sleep")]
-    fn sleep_(py: Python) -> PyResult<&PyAny> {
+    fn sleep_(py: Python) -> PyResult<Bound<PyAny>> {
         pyo3_asyncio::async_std::future_into_py(py, async move {
             async_std::task::sleep(Duration::from_millis(500)).await;
             Ok(())
@@ -305,7 +305,7 @@ fn test_multiple_asyncio_run() -> PyResult<()> {
 fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction]
-    pub(crate) fn async_callback(py: Python, callback: PyObject) -> PyResult<&PyAny> {
+    pub(crate) fn async_callback(py: Python, callback: PyObject) -> PyResult<Bound<PyAny>> {
         pyo3_asyncio::async_std::future_into_py(py, async move {
             Python::with_gil(|py| {
                 pyo3_asyncio::async_std::into_future(callback.as_ref(py).call0()?)

--- a/pytests/test_race_condition_regression.rs
+++ b/pytests/test_race_condition_regression.rs
@@ -1,7 +1,7 @@
 use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
-fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+fn sleep<'p>(py: Python<'p>, secs: Bound<PyAny>) -> PyResult<Bound<PyAny>> {
     let secs = secs.extract()?;
 
     pyo3_asyncio::async_std::future_into_py(py, async move {

--- a/pytests/tokio_asyncio/mod.rs
+++ b/pytests/tokio_asyncio/mod.rs
@@ -17,7 +17,7 @@ use futures::{StreamExt, TryStreamExt};
 use crate::common;
 
 #[pyfunction]
-fn sleep<'p>(py: Python<'p>, secs: &'p PyAny) -> PyResult<&'p PyAny> {
+fn sleep<'p>(py: Python<'p>, secs: Bound<PyAny>) -> PyResult<Bound<PyAny>> {
     let secs = secs.extract()?;
 
     pyo3_asyncio::tokio::future_into_py(py, async move {
@@ -233,7 +233,7 @@ fn test_local_cancel(event_loop: PyObject) -> PyResult<()> {
 fn test_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction(name = "sleep")]
-    fn sleep_(py: Python) -> PyResult<&PyAny> {
+    fn sleep_(py: Python) -> PyResult<Bound<PyAny>> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
             tokio::time::sleep(Duration::from_millis(500)).await;
             Ok(())
@@ -280,7 +280,7 @@ fn test_multiple_asyncio_run() -> PyResult<()> {
 fn cvars_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     #![allow(deprecated)]
     #[pyfunction]
-    fn async_callback(py: Python, callback: PyObject) -> PyResult<&PyAny> {
+    fn async_callback(py: Python, callback: PyObject) -> PyResult<Bound<PyAny>> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
             Python::with_gil(|py| pyo3_asyncio::tokio::into_future(callback.as_ref(py).call0()?))?
                 .await?;

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -230,10 +230,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -285,10 +285,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -331,10 +331,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -406,10 +406,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -230,10 +230,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -285,10 +285,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -331,10 +331,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -406,10 +406,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -472,10 +472,10 @@ where
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -744,10 +744,10 @@ impl PyDoneCallback {
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -852,10 +852,10 @@ where
 /// specification of task locals.
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -1057,10 +1057,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -472,10 +472,10 @@ where
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -744,10 +744,10 @@ impl PyDoneCallback {
 /// Convert a Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -852,10 +852,10 @@ where
 /// specification of task locals.
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -1057,10 +1057,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable with a generic runtime
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -272,10 +272,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -327,10 +327,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -373,10 +373,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -464,10 +464,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
+/// the Rust future will be cancelled as well (new behavior in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behaviour in `v0.15`).
+/// via [`into_future`] (new behavior in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -272,10 +272,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -327,10 +327,10 @@ where
 /// Convert a Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -373,10 +373,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the
@@ -464,10 +464,10 @@ where
 /// Convert a `!Send` Rust Future into a Python awaitable
 ///
 /// If the `asyncio.Future` returned by this conversion is cancelled via `asyncio.Future.cancel`,
-/// the Rust future will be cancelled as well (new behavior in `v0.15`).
+/// the Rust future will be cancelled as well (new behaviour in `v0.15`).
 ///
 /// Python `contextvars` are preserved when calling async Python functions within the Rust future
-/// via [`into_future`] (new behavior in `v0.15`).
+/// via [`into_future`] (new behaviour in `v0.15`).
 ///
 /// > Although `contextvars` are preserved for async Python functions, synchronous functions will
 /// unfortunately fail to resolve them when called within the Rust future. This is because the


### PR DESCRIPTION
Thank you for contributing to pyo3-asyncio!

Please consider adding the following to your pull request:
 - an entry in CHANGELOG.md
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

Be aware the CI pipeline will check your pull request for the following:
 - Rust tests (Just `cargo test`)
 - Rust lints (`make clippy`)
 - Rust formatting (`cargo fmt`)
 - Python formatting (`black . --check`. You can install black with `pip install black`)

Fixes #119.

Ref: https://pyo3.rs/v0.21.0/migration.html

I've updated pyo3-asyncio code referring to the migration guide. 
I'd appreciate it if you could let me know if there's anything I've missed.